### PR TITLE
remove useless check in column_as_rownames()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
     person("Mattan S.", "Ben-Shachar", , "matanshm@post.bgu.ac.il", role = "aut",
            comment = c(ORCID = "0000-0002-4287-4801")),
     person("Brenton M.", "Wiernik", , "brenton@wiernik.org", role = "aut",
-           comment = c(ORCID = "0000-0001-9560-6336", Twitter = "@bmwiernik"))
+           comment = c(ORCID = "0000-0001-9560-6336", Twitter = "@bmwiernik")),
+    person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = "ctb")
   )
 Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
 Description: A lightweight package to easily manipulate, clean, transform,

--- a/R/utils_data.R
+++ b/R/utils_data.R
@@ -45,9 +45,6 @@ column_as_rownames <- function(x, var = "rowname") {
   if (!is.character(var) & !is.numeric(var)) {
     stop("Argument 'var' must be of type character or numeric.")
   }
-  if (is.null(var)) {
-    var <- "rowname"
-  }
   if (is.character(var)) {
     if (!var %in% names(x)) {
       stop(paste0('Variable "', var, '" is not in the dataframe.'))


### PR DESCRIPTION
Remove condition when `var = NULL` in `column_as_rownames()` as this case is already taken into account by sanity checks.

Close #95 