### PR TITLE
Improve data_rename()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,10 @@ MINOR CHANGES
   * Improved support for *labelled data* for many functions, i.e. returned
     data frame will preserve value and variable label attributes, where
     possible and applicable.
+    
+  * `data_rename()` now throws an error if `pattern = NULL` and if the length 
+  of `replacement` is not equal to the number of columns of `data`
+  (@etiennebacher, #99).
 
 BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,9 +24,11 @@ MINOR CHANGES
     data frame will preserve value and variable label attributes, where
     possible and applicable.
     
-  * `data_rename()` now throws an error if `pattern = NULL` and if the length 
-  of `replacement` is not equal to the number of columns of `data`
-  (@etiennebacher, #99).
+  * `data_rename()` doesn't use `pattern` anymore to rename the columns if
+  `replacement` is not provided (@etiennebacher).
+  
+  * `data_rename()` now adds a suffix to duplicated names in `replacement` 
+  (@etiennebacher).
 
 BUG FIXES
 

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -48,6 +48,10 @@ data_rename <- function(data, pattern = NULL, replacement = NULL, safe = TRUE, .
     pattern <- names(data)
   }
 
+  if (!is.character(pattern)) {
+    stop("Argument 'pattern' must be of type character.")
+  }
+
   # name columns 1, 2, 3 etc. if no replacement
   if (is.null(replacement)) {
     replacement <- paste0(1:length(pattern))

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -50,7 +50,7 @@ data_rename <- function(data, pattern = NULL, replacement = NULL, safe = TRUE, .
 
   # name columns 1, 2, 3 etc. if no replacement
   if (is.null(replacement)) {
-    replacement <- paste0("col", 1:length(pattern))
+    replacement <- paste0(1:length(pattern))
   }
 
   # if duplicated names in replacement, append ".2", ".3", etc. to duplicates

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -43,29 +43,44 @@
 #' @export
 data_rename <- function(data, pattern = NULL, replacement = NULL, safe = TRUE, ...) {
 
-  # sanity checks
-  if (is.null(replacement) && is.null(pattern)) {
-    names(data) <- c(1:ncol(data))
-    return(data)
+  # change all names if no pattern specified
+  if (is.null(pattern)) {
+    pattern <- names(data)
   }
 
-  if (is.null(replacement) && !is.null(pattern)) {
-    names(data) <- pattern
-    return(data)
+  # name columns 1, 2, 3 etc. if no replacement
+  if (is.null(replacement)) {
+    replacement <- paste0("col", 1:length(pattern))
   }
 
-  if (!is.null(replacement) && is.null(pattern)) {
-    names(data) <- replacement
-    return(data)
+  # if duplicated names in replacement, append ".2", ".3", etc. to duplicates
+  # ex: c("foo", "foo") -> c("foo", "foo.2")
+  if (any(duplicated(replacement))) {
+    dup <- as.data.frame(table(replacement))
+    dup <- dup[dup$Freq > 1,]
+    for (i in dup$replacement) {
+      to_replace <- which(replacement == i)[-1]
+      new_replacement <- paste0(i, ".", 1+1:length(to_replace))
+      replacement[to_replace] <- new_replacement
+    }
   }
 
-
-  if (length(pattern) != length(replacement)) {
-    stop("The 'replacement' names must be of the same length than the variable names.")
+  if (length(replacement) > length(pattern)) {
+    message(
+      paste0("There are more names in 'replacement' than in 'pattern'. The last ",
+             length(replacement) - length(pattern), " names of 'replacement' are not used.")
+    )
+  } else if (length(replacement) < length(pattern)) {
+    message(
+      paste0("There are more names in 'pattern' than in 'replacement'. The last ",
+             length(pattern) - length(replacement), " names of 'pattern' are not modified.")
+    )
   }
 
   for (i in 1:length(pattern)) {
-    data <- .data_rename(data, pattern[i], replacement[i], safe)
+    if (!is.na(replacement[i])) {
+      data <- .data_rename(data, pattern[i], replacement[i], safe)
+    }
   }
 
   data

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -19,6 +19,17 @@ test_that("data_rename returns a dataframe", {
   expect_true(class(x) == "data.frame")
 })
 
+test_that("data_rename: pattern must be of type character", {
+  expect_error(
+    data_rename(test, pattern = 1),
+    regexp = "Argument 'pattern' must be of type character."
+  )
+  expect_error(
+    data_rename(test, pattern = TRUE),
+    regexp = "Argument 'pattern' must be of type character."
+  )
+})
+
 # replacement -------------
 
 test_that("data_rename uses indices when no replacement", {

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -1,69 +1,88 @@
 test <- head(iris)
 
+# basic tests --------------
+
+test_that("data_rename works with one or several replacements", {
+  expect_equal(
+    names(data_rename(test, "Sepal.Length", "length")),
+    c("length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
+  )
+  expect_equal(
+    names(data_rename(test, c("Sepal.Length", "Sepal.Width"),
+                      c("length", "width"))),
+    c("length", "width", "Petal.Length", "Petal.Width", "Species")
+  )
+})
+
+test_that("data_rename returns a dataframe", {
+  x <- data_rename(test, "Sepal.Length", "length")
+  expect_true(class(x) == "data.frame")
+})
+
+# replacement -------------
+
+test_that("data_rename uses indices when no replacement", {
+  x <- data_rename(test, pattern = c("Sepal.Length", "Petal.Length"))
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x), c("1", "Sepal.Width",  "2", "Petal.Width", "Species"))
+})
+
+test_that("data_rename works when too many names in 'replacement'", {
+  expect_message(
+    x <- data_rename(test, replacement = paste0("foo", 1:6)),
+    "There are more names in 'replacement' than in 'pattern'. The last 1 names of 'replacement' are not used."
+  )
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x), paste0("foo", 1:5))
+})
+
+test_that("data_rename works when not enough names in 'replacement'", {
+  expect_message(
+    x <- data_rename(test, replacement = paste0("foo", 1:2)),
+    "There are more names in 'pattern' than in 'replacement'. The last 3 names of 'pattern' are not modified."
+  )
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x), c("foo1", "foo2", "Petal.Length", "Petal.Width", "Species"))
+})
+
+
 # no pattern --------------
 
-test_that("data_rename works when no pattern and no replacement", {
-  x <- data_rename(test)
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x), paste0("col", 1:5))
+test_that("data_rename uses the whole dataset when pattern = NULL", {
+  x1 <- data_rename(test)
+  x2 <- data_rename(test, pattern = names(test))
+  expect_equal(dim(test), dim(x1))
+  expect_identical(x1, x2)
+
+  x3 <- data_rename(test, replacement = paste0("foo", 1:5))
+  x4 <- data_rename(test, pattern = names(test), replacement = paste0("foo", 1:5))
+  expect_equal(dim(test), dim(x3))
+  expect_identical(x3, x4)
 })
 
-test_that("data_rename works when no pattern and not enough replacement", {
-  expect_message(
-    x <- data_rename(test, replacement = c("foo", "bar")),
-    "There are more names in 'pattern' than in 'replacement'. The last 3 names of 'pattern' are not modified."
+
+# other --------------
+
+test_that("data_rename: argument 'safe' works", {
+  expect_silent(
+    data_rename(iris, "FakeCol", "length", safe = TRUE)
   )
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x[, 1:2]), c("foo", "bar"))
-  expect_equal(names(x[, 3:5]), names(test[, 3:5]))
-})
-
-test_that("data_rename works when no pattern and too many replacement", {
-  expect_message(
-    x <- data_rename(test, replacement = c("foo", "bar")),
-    "There are more names in 'pattern' than in 'replacement'. The last 3 names of 'pattern' are not modified."
+  expect_error(
+    data_rename(iris, "FakeCol", "length", safe = FALSE),
+    "Variable 'FakeCol' is not in your dataframe"
   )
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x[, 1:2]), c("foo", "bar"))
-  expect_equal(names(x[, 3:5]), names(test[, 3:5]))
 })
 
+test_that("data_rename deals correctly with duplicated replacement", {
+  x <- data_rename(test, pattern = names(test)[1:4],
+                   replacement = c("foo", "bar", "foo", "bar"))
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x)[1:4], c("foo", "bar", "foo.2", "bar.2"))
+})
 
-
-
-
-
-expect_error(
-  data_rename(iris, "FakeCol", "length", safe = FALSE),
-  "Variable 'FakeCol' is not in your dataframe"
-)
-
-expect_equal(
-  names(data_rename(iris, "Sepal.Length", "length")),
-  c("length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
-)
-
-expect_equal(
-  names(data_rename(iris, "FakeCol", "length")),
-  names(iris)
-)
-
-expect_equal(
-  names(data_rename(iris, c("Sepal.Length", "Sepal.Width"), c("length", "width"))),
-  c("length", "width", "Petal.Length", "Petal.Width", "Species")
-)
-
-expect_equal(
-  names(data_rename(iris, NULL)),
-  c("1", "2", "3", "4", "5")
-)
-
-expect_equal(
-  names(data_rename(iris, paste0("Var", 1:5))),
-  paste0("Var", 1:5)
-)
-
-expect_error(
-  data_rename(iris, replacement = "foo"),
-  regexp = "The 'replacement' names must be of the same length than the variable names."
-)
+test_that("data_rename doesn't change colname if invalid pattern", {
+  expect_equal(
+    names(data_rename(test, "FakeCol", "length")),
+    names(test)
+  )
+})

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -1,31 +1,69 @@
-test_that("data_remove works as expected", {
-  expect_error(
-    data_rename(iris, "FakeCol", "length", safe = FALSE),
-    "Variable 'FakeCol' is not in your dataframe"
-  )
+test <- head(iris)
 
-  expect_equal(
-    names(data_rename(iris, "Sepal.Length", "length")),
-    c("length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
-  )
+# no pattern --------------
 
-  expect_equal(
-    names(data_rename(iris, "FakeCol", "length")),
-    names(iris)
-  )
-
-  expect_equal(
-    names(data_rename(iris, c("Sepal.Length", "Sepal.Width"), c("length", "width"))),
-    c("length", "width", "Petal.Length", "Petal.Width", "Species")
-  )
-
-  expect_equal(
-    names(data_rename(iris, NULL)),
-    c("1", "2", "3", "4", "5")
-  )
-
-  expect_equal(
-    names(data_rename(iris, paste0("Var", 1:5))),
-    paste0("Var", 1:5)
-  )
+test_that("data_rename works when no pattern and no replacement", {
+  x <- data_rename(test)
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x), paste0("col", 1:5))
 })
+
+test_that("data_rename works when no pattern and not enough replacement", {
+  expect_message(
+    x <- data_rename(test, replacement = c("foo", "bar")),
+    "There are more names in 'pattern' than in 'replacement'. The last 3 names of 'pattern' are not modified."
+  )
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x[, 1:2]), c("foo", "bar"))
+  expect_equal(names(x[, 3:5]), names(test[, 3:5]))
+})
+
+test_that("data_rename works when no pattern and too many replacement", {
+  expect_message(
+    x <- data_rename(test, replacement = c("foo", "bar")),
+    "There are more names in 'pattern' than in 'replacement'. The last 3 names of 'pattern' are not modified."
+  )
+  expect_equal(dim(test), dim(x))
+  expect_equal(names(x[, 1:2]), c("foo", "bar"))
+  expect_equal(names(x[, 3:5]), names(test[, 3:5]))
+})
+
+
+
+
+
+
+expect_error(
+  data_rename(iris, "FakeCol", "length", safe = FALSE),
+  "Variable 'FakeCol' is not in your dataframe"
+)
+
+expect_equal(
+  names(data_rename(iris, "Sepal.Length", "length")),
+  c("length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
+)
+
+expect_equal(
+  names(data_rename(iris, "FakeCol", "length")),
+  names(iris)
+)
+
+expect_equal(
+  names(data_rename(iris, c("Sepal.Length", "Sepal.Width"), c("length", "width"))),
+  c("length", "width", "Petal.Length", "Petal.Width", "Species")
+)
+
+expect_equal(
+  names(data_rename(iris, NULL)),
+  c("1", "2", "3", "4", "5")
+)
+
+expect_equal(
+  names(data_rename(iris, paste0("Var", 1:5))),
+  paste0("Var", 1:5)
+)
+
+expect_error(
+  data_rename(iris, replacement = "foo"),
+  regexp = "The 'replacement' names must be of the same length than the variable names."
+)


### PR DESCRIPTION
This PR is related to #98. It reorganizes the code in `data_rename()`, fixes the bug in #98, adds more tests and a few features:

* a suffix is now added to duplicated names in `replacement`:
```r
> head(data_rename(iris, pattern = names(iris)[1:5], replacement = c("foo", "bar", "foo", "bar", "foo")))

  foo bar foo.2 bar.2  foo.3
1 5.1 3.5   1.4   0.2 setosa
2 4.9 3.0   1.4   0.2 setosa
3 4.7 3.2   1.3   0.2 setosa
4 4.6 3.1   1.5   0.2 setosa
5 5.0 3.6   1.4   0.2 setosa
6 5.4 3.9   1.7   0.4 setosa
```
* there are now messages if `length(replacement) != length(pattern)`:
```r
> head(data_rename(iris, pattern = "Sepal.Length", replacement = c("foo", "bar")))
There are more names in 'replacement' than in 'pattern'. The last 1 names of 'replacement' are not used.
  foo Sepal.Width Petal.Length Petal.Width Species
1 5.1         3.5          1.4         0.2  setosa
2 4.9         3.0          1.4         0.2  setosa
3 4.7         3.2          1.3         0.2  setosa
4 4.6         3.1          1.5         0.2  setosa
5 5.0         3.6          1.4         0.2  setosa
6 5.4         3.9          1.7         0.4  setosa

> head(data_rename(iris, pattern = c("Sepal.Length", "Petal.Length"), replacement = "foo"))
There are more names in 'pattern' than in 'replacement'. The last 1 names of 'pattern' are not modified.
  foo Sepal.Width Petal.Length Petal.Width Species
1 5.1         3.5          1.4         0.2  setosa
2 4.9         3.0          1.4         0.2  setosa
3 4.7         3.2          1.3         0.2  setosa
4 4.6         3.1          1.5         0.2  setosa
5 5.0         3.6          1.4         0.2  setosa
6 5.4         3.9          1.7         0.4  setosa
```

Close #98.