### PR TITLE
Improve select nse

### DIFF
--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -1,18 +1,24 @@
 # this function evaluates the select-expression and allows non-standard evaluation
 
 .select_nse <- function(select, data, exclude, ignore_case, verbose = FALSE) {
-  fixed <- TRUE
+  fixed_select <- TRUE
+  fixed_exclude <- TRUE
   # avoid conflicts
   conflicting_packages <- .conflicting_packages("poorman")
 
   # in case pattern is a variable from another function call...
   p <- try(eval(select), silent = TRUE)
+  p2 <- try(eval(exclude), silent = TRUE)
   if (inherits(p, c("try-error", "simpleError"))) {
     p <- substitute(select, env = parent.frame())
+  }
+  if (inherits(p2, c("try-error", "simpleError"))) {
+    p2 <- substitute(exclude, env = parent.frame())
   }
 
   # check if pattern is a function like "starts_with()"
   select <- tryCatch(eval(p), error = function(e) NULL)
+  exclude <- tryCatch(eval(p2), error = function(e) NULL)
 
   # if select could not be evaluated (because expression "makes no sense")
   # try to evaluate and find select-helpers. In this case, set fixed = FALSE,
@@ -20,12 +26,25 @@
   if (is.null(select)) {
     evaluated_pattern <- .evaluate_pattern(insight::safe_deparse(p), data, ignore_case = ignore_case)
     select <- evaluated_pattern$pattern
-    fixed <- evaluated_pattern$fixed
+    fixed_select <- evaluated_pattern$fixed
+  }
+  if (is.null(exclude)) {
+    evaluated_pattern <- .evaluate_pattern(insight::safe_deparse(p2), data, ignore_case = ignore_case)
+    exclude <- evaluated_pattern$pattern
+    fixed_exclude <- evaluated_pattern$fixed
   }
 
+
   # seems to be no valid column name or index, so try to grep
-  if (isFALSE(fixed)) {
+  if (isFALSE(fixed_select)) {
     select <- colnames(data)[grepl(select, colnames(data), ignore.case = ignore_case)]
+  }
+  if (isFALSE(fixed_exclude)) {
+    exclude <- colnames(data)[grepl(exclude, colnames(data), ignore.case = ignore_case)]
+  }
+  # if exclude = NULL, we want to exclude 0 variables, not all of them
+  if (length(exclude) == ncol(data)) {
+    exclude <- NULL
   }
 
   # load again

--- a/tests/testthat/test-select_nse.R
+++ b/tests/testthat/test-select_nse.R
@@ -1,0 +1,77 @@
+foo <- function(data, select = NULL, exclude = NULL) {
+  .select_nse(select, data, exclude = exclude, ignore_case = FALSE)
+}
+
+test_that(".select_nse: arg 'select' works", {
+  expect_equal(
+    foo(iris, select = NULL),
+    names(iris)
+  )
+  expect_equal(
+    foo(iris, c("Petal.Length", "Sepal.Width")),
+    c("Petal.Length", "Sepal.Width")
+  )
+  expect_equal(
+    foo(iris, c(3, 2)),
+    c("Petal.Length", "Sepal.Width")
+  )
+  expect_equal(
+    foo(iris, 1:5),
+    names(iris)
+  )
+  expect_equal(
+    foo(iris, starts_with("Petal")),
+    c("Petal.Length", "Petal.Width")
+  )
+  expect_equal(
+    foo(iris, ends_with("Length")),
+    c("Sepal.Length", "Petal.Length")
+  )
+  expect_equal(
+    foo(iris, contains("Length")),
+    c("Sepal.Length", "Petal.Length")
+  )
+  expect_equal(
+    foo(iris, regex("Length$")),
+    c("Sepal.Length", "Petal.Length")
+  )
+})
+
+
+test_that(".select_nse: arg 'exclude' works", {
+  expect_equal(
+    foo(iris, exclude = c("Petal.Length", "Sepal.Width")),
+    c("Sepal.Length", "Petal.Width", "Species")
+  )
+  expect_equal(
+    foo(iris, exclude = c(3, 2)),
+    c("Sepal.Length", "Petal.Width", "Species")
+  )
+  expect_equal(
+    foo(iris, exclude = starts_with("Petal")),
+    c("Sepal.Length", "Sepal.Width", "Species")
+  )
+  expect_equal(
+    foo(iris, exclude = ends_with("Length")),
+    c("Sepal.Width", "Petal.Width", "Species")
+  )
+  expect_equal(
+    foo(iris, exclude = contains("Length")),
+    c("Sepal.Width", "Petal.Width", "Species")
+  )
+  expect_equal(
+    foo(iris, exclude = regex("Length$")),
+    c("Sepal.Width", "Petal.Width", "Species")
+  )
+})
+
+test_that(".select_nse: args 'select' and 'exclude' at the same time", {
+  expect_equal(
+    foo(iris, select = contains("Length"), exclude = starts_with("Petal")),
+    c("Sepal.Length")
+  )
+  expect_equal(
+    foo(iris, select = contains("Length"), exclude = contains("Length")),
+    character(0)
+  )
+})


### PR DESCRIPTION
Add NSE for exclude and add tests for `.select_nse`. Some examples:
``` r
foo <- function(data, select = NULL, exclude = NULL) {
  datawizard:::.select_nse(select, data, exclude = exclude, ignore_case = FALSE)
}
foo(iris, exclude = starts_with("Petal"))
#> [1] "Sepal.Length" "Sepal.Width"  "Species"
foo(iris, exclude = ends_with("Length"))
#> [1] "Sepal.Width" "Petal.Width" "Species"
foo(iris, exclude = NULL)
#> [1] "Sepal.Length" "Sepal.Width"  "Petal.Length" "Petal.Width"  "Species"
```

<sup>Created on 2022-03-19 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
