### PR TITLE
data_match: return filtered data by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 MAJOR CHANGES
 
+* `data_match()` now returns filtered data by default. Old behavior (returning rows indices) can be set by setting `return_indices = TRUE`.
+
 * The following functions are now re-exported from `{insight}` package:
 `object_has_names()`, `object_has_rownames()`, `is_empty_object()`,
 `compact_list()`, `compact_character()`
@@ -11,17 +13,17 @@ MAJOR CHANGES
 NEW FUNCTIONS
 
   * To convert rownames to a column, and *vice versa*: `rownames_as_column()` and `column_as_rownames()` (@etiennebacher, #80).
-  
+
   * For computing weighted centrality measures and dispersion: `weighted_mean()`, `weighted_median()`, `weighted_sd()` and `weighted_mad()` .
 
 MINOR CHANGES
 
-  * The `select` argument in several functions (like `data_remove()`, 
+  * The `select` argument in several functions (like `data_remove()`,
     `data_findcols()`, or  `data_extract()`) now allow the use of select-helpers
     for selecting variables based on specific patterns.
 
   * `data_extract()` gains new arguments to allow type-safe return values,
-    i.e. *always* return a vector *or* a data frame. Thus, `data_extract()` 
+    i.e. *always* return a vector *or* a data frame. Thus, `data_extract()`
     can now be used to select multiple variables or pull a single variable
     from data frames.
 
@@ -34,18 +36,18 @@ MINOR CHANGES
   * Improved support for *labelled data* for many functions, i.e. returned
     data frame will preserve value and variable label attributes, where
     possible and applicable.
-    
+
   * `describe_distribution()` now works with lists (@etiennebacher, #105).
 
   * `data_rename()` doesn't use `pattern` anymore to rename the columns if
   `replacement` is not provided (@etiennebacher, #103).
-  
-  * `data_rename()` now adds a suffix to duplicated names in `replacement` 
+
+  * `data_rename()` now adds a suffix to duplicated names in `replacement`
   (@etiennebacher, #103).
 
 BUG FIXES
 
-  * `data_to_numeric()` produced wrong results for factors when 
+  * `data_to_numeric()` produced wrong results for factors when
     `dummy_factors = TRUE` and factor contained missing values.
 
   * `data_match()` produced wrong results when data contained missing values.
@@ -64,16 +66,16 @@ NEW FUNCTIONS
   * To check for names: `object_has_names()` and `object_has_rownames()`.
 
   * To rotate data frames: `data_rotate()`.
-  
+
   * To reverse score variables: `data_reverse()`.
-  
+
   * To merge/join multiple data frames: `data_merge()` (or its alias
     `data_join()`).
 
   * To cut (recode) data into groups: `data_cut()`.
-  
+
   * To replace specific values with `NA`s: `convert_to_na()`.
-  
+
   * To replace `Inf` and `NaN` values with `NA`s: `replace_nan_inf()`.
 
 - Arguments `cols`, `before` and `after` in `data_relocate()` can now also be

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -14,21 +14,15 @@
 #' @return The row indices that match the specified configuration.
 #'
 #' @examples
-#' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
-#' mtcars[matching_rows, ]
-#' # Filtered data can be obtained directly using:
-#'
-#'
-#' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
-#' mtcars[matching_rows, ]
+#' data_match(mtcars, data.frame(vs = 0, am = 1))
+#' data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
 #'
 #' # observations where "vs" is NOT 0 AND "am" is NOT 1
-#' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1), match = "not")
-#' mtcars[matching_rows, ]
+#' data_match(mtcars, data.frame(vs = 0, am = 1), match = "not")
 #'
 #' # observations where EITHER "vs" is 0 OR "am" is 1
-#' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1), match = "or")
-#' mtcars[matching_rows, ]
+#' data_match(mtcars, data.frame(vs = 0, am = 1), match = "or")
+#'
 #' @inherit data_rename seealso
 #' @export
 data_match <- function(x, to, match = "and", return_indices = FALSE, ...) {

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -7,7 +7,7 @@
 #' @param match String, indicating with which logical operation matching
 #'   conditions should be combined. Can be `"and"` (or `"&"`), `"or"` (or `"|"`)
 #'   or `"not"` (or `"!"`).
-#' @param as_data_frame Logical, if `TRUE`, returns the filtered data frame
+#' @param return_indices Logical, if `FALSE`, return the vector of rows that can be used to filter the original data frame. If `FALSE` (default), returns directly the filtered data frame
 #'   instead of the row indices.
 #' @param ... Not used.
 #'
@@ -16,6 +16,8 @@
 #' @examples
 #' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
 #' mtcars[matching_rows, ]
+#' # Filtered data can be obtained directly using:
+#'
 #'
 #' matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
 #' mtcars[matching_rows, ]
@@ -29,7 +31,7 @@
 #' mtcars[matching_rows, ]
 #' @inherit data_rename seealso
 #' @export
-data_match <- function(x, to, match = "and", as_data_frame = FALSE, ...) {
+data_match <- function(x, to, match = "and", return_indices = FALSE, ...) {
 
   # Input checks
   if (!is.data.frame(to)) to <- as.data.frame(to)
@@ -77,7 +79,7 @@ data_match <- function(x, to, match = "and", as_data_frame = FALSE, ...) {
   }
 
   # prepare output
-  if (isTRUE(as_data_frame)) {
+  if (isFALSE(return_indices)) {
     out <- original_x[idx, , drop = FALSE]
     # restore value and variable labels
     for (i in colnames(out)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -54,8 +54,7 @@ citation("datawizard")
 The package provides helpers to filter rows meeting certain conditions:
 
 ```{r}
-matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
-mtcars[matching_rows, ]
+data_match(mtcars, data.frame(vs = 0, am = 1))
 ```
 
 It is also possible to select one or more variables:

--- a/man/data_match.Rd
+++ b/man/data_match.Rd
@@ -27,21 +27,15 @@ The row indices that match the specified configuration.
 Find row indices of a data frame that match a specific condition.
 }
 \examples{
-matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
-mtcars[matching_rows, ]
-# Filtered data can be obtained directly using:
-
-
-matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
-mtcars[matching_rows, ]
+data_match(mtcars, data.frame(vs = 0, am = 1))
+data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
 
 # observations where "vs" is NOT 0 AND "am" is NOT 1
-matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1), match = "not")
-mtcars[matching_rows, ]
+data_match(mtcars, data.frame(vs = 0, am = 1), match = "not")
 
 # observations where EITHER "vs" is 0 OR "am" is 1
-matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1), match = "or")
-mtcars[matching_rows, ]
+data_match(mtcars, data.frame(vs = 0, am = 1), match = "or")
+
 }
 \seealso{
 \itemize{

--- a/man/data_match.Rd
+++ b/man/data_match.Rd
@@ -4,7 +4,7 @@
 \alias{data_match}
 \title{Find row indices of a data frame matching a specific condition}
 \usage{
-data_match(x, to, match = "and", as_data_frame = FALSE, ...)
+data_match(x, to, match = "and", return_indices = FALSE, ...)
 }
 \arguments{
 \item{x}{A data frame.}
@@ -15,7 +15,7 @@ data_match(x, to, match = "and", as_data_frame = FALSE, ...)
 conditions should be combined. Can be \code{"and"} (or \code{"&"}), \code{"or"} (or \code{"|"})
 or \code{"not"} (or \code{"!"}).}
 
-\item{as_data_frame}{Logical, if \code{TRUE}, returns the filtered data frame
+\item{return_indices}{Logical, if \code{FALSE}, return the vector of rows that can be used to filter the original data frame. If \code{FALSE} (default), returns directly the filtered data frame
 instead of the row indices.}
 
 \item{...}{Not used.}
@@ -29,6 +29,8 @@ Find row indices of a data frame that match a specific condition.
 \examples{
 matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
 mtcars[matching_rows, ]
+# Filtered data can be obtained directly using:
+
 
 matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
 mtcars[matching_rows, ]

--- a/tests/testthat/test-data_match.R
+++ b/tests/testthat/test-data_match.R
@@ -1,12 +1,12 @@
 data(efc, package = "datawizard")
 
 test_that("data_match works as expected", {
-  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1))
+  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = 1), return_indices = TRUE)
   df1 <- mtcars[matching_rows, ]
   expect_equal(unique(df1$vs), 0)
   expect_equal(unique(df1$am), 1)
 
-  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)))
+  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1), return_indices = TRUE))
   df2 <- mtcars[matching_rows, ]
   expect_equal(unique(df2$vs), 0)
   expect_equal(unique(df2$am), c(1, 0))
@@ -16,17 +16,17 @@ test_that("data_match works with missing data", {
   skip_if_not_installed("poorman")
 
   # "OR" works
-  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "or"))
+  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "or", return_indices = TRUE))
   x2 <- nrow(poorman::filter(efc, c172code == 1 | e16sex == 2))
   expect_equal(x1, x2)
 
   # "AND" works
-  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "and"))
+  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "and", return_indices = TRUE))
   x2 <- nrow(poorman::filter(efc, c172code == 1, e16sex == 2))
   expect_equal(x1, x2)
 
   # "NOT" works
-  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "not"))
+  x1 <- length(data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "not", return_indices = TRUE))
   x2 <- nrow(poorman::filter(efc, c172code != 1, e16sex != 2))
   expect_equal(x1, x2)
 })

--- a/tests/testthat/test-data_match.R
+++ b/tests/testthat/test-data_match.R
@@ -6,7 +6,7 @@ test_that("data_match works as expected", {
   expect_equal(unique(df1$vs), 0)
   expect_equal(unique(df1$am), 1)
 
-  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1), return_indices = TRUE))
+  matching_rows <- data_match(mtcars, data.frame(vs = 0, am = c(0, 1)), return_indices = TRUE)
   df2 <- mtcars[matching_rows, ]
   expect_equal(unique(df2$vs), 0)
   expect_equal(unique(df2$am), c(1, 0))

--- a/tests/testthat/test-labelled_data.R
+++ b/tests/testthat/test-labelled_data.R
@@ -222,7 +222,7 @@ test_that("data_to_numeric, labels preserved", {
 # data_match -----------------------------------
 
 test_that("data_match, labels preserved", {
-  x <- data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "or", as_data_frame = TRUE)
+  x <- data_match(efc, data.frame(c172code = 1, e16sex = 2), match = "or")
   # factor
   expect_equal(
     attr(x$e42dep, "label", exact = TRUE),


### PR DESCRIPTION
@strengejacke I think you're right, returning the filtered should be default behavior as it's more consistent with the other `data_*` functions. I'll open PRs in the repos (mostly modelbased) where it needs to be fixed according to this (breaking) change, and then we can merge this