### PR TITLE
Deprecate before and after in data_relocate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling
-Version: 0.4.1.6
+Version: 0.4.1.7
 Authors@R: c(
     person("Dominique", "Makowski", , "dom.makowski@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-5375-9967", Twitter = "@Dom_Makowski")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,9 @@ CHANGES
 
 * `data_partition()` now allows to create multiple partitions from the data,
   returning multiple training and a remaining test set.
+  
+* Arguments `before` and `after` are deprecated in `data_relocate()` for 
+  consistency with `dplyr::relocate()`. Use `.before` and `.after` instead.
 
 NEW FUNCTIONS
 

--- a/R/data_relocate.R
+++ b/R/data_relocate.R
@@ -10,13 +10,14 @@
 #' be reordered or removed.
 #'
 #' @param data A data frame.
-#' @param before,after Destination of columns. Supplying neither will move
+#' @param .before,.after Destination of columns. Supplying neither will move
 #'   columns to the left-hand side; specifying both is an error. Can be a
 #'   character vector, indicating the name of the destination column, or a
 #'   numeric value, indicating the index number of the destination column.
 #'   If `-1`, will be added before or after the last column.
 #' @inheritParams find_columns
 #' @inheritParams data_rename
+#' @param before,after Deprecated. Please use `.before` and `.after` instead.
 #'
 #' @inherit data_rename seealso
 #'
@@ -42,36 +43,51 @@
 #' @export
 data_relocate <- function(data,
                           select,
-                          before = NULL,
-                          after = NULL,
+                          .before = NULL,
+                          .after = NULL,
                           ignore_case = FALSE,
                           verbose = TRUE,
-                          ...) {
+                          ...,
+                          before,
+                          after) {
+
+  if (!missing(before)) {
+    .is_deprecated("before", ".before")
+    if (is.null(.before)) {
+      .before <- before
+    }
+  }
+  if (!missing(after)) {
+    .is_deprecated("after", ".after")
+    if (is.null(.after)) {
+      .after <- after
+    }
+  }
 
   # Sanitize
-  if (!is.null(before) && !is.null(after)) {
-    stop("You must supply only one of `before` or `after`.")
+  if (!is.null(.before) && !is.null(.after)) {
+    stop("You must supply only one of `.before` or `.after`.")
   }
 
   # allow numeric values
-  if (!is.null(before) && is.numeric(before)) {
-    if (before == -1) {
-      before <- names(data)[ncol(data)]
-    } else if (before >= 1 && before <= ncol(data)) {
-      before <- names(data)[before]
+  if (!is.null(.before) && is.numeric(.before)) {
+    if (.before == -1) {
+      .before <- names(data)[ncol(data)]
+    } else if (.before >= 1 && .before <= ncol(data)) {
+      .before <- names(data)[.before]
     } else {
-      stop("No valid position defined in 'before'.", call. = FALSE)
+      stop("No valid position defined in '.before'.", call. = FALSE)
     }
   }
 
   # allow numeric values
-  if (!is.null(after) && is.numeric(after)) {
-    if (after == -1) {
-      after <- names(data)[ncol(data)]
-    } else if (after >= 1 && after <= ncol(data)) {
-      after <- names(data)[after]
+  if (!is.null(.after) && is.numeric(.after)) {
+    if (.after == -1) {
+      .after <- names(data)[ncol(data)]
+    } else if (.after >= 1 && .after <= ncol(data)) {
+      .after <- names(data)[.after]
     } else {
-      stop("No valid position defined in 'after'.", call. = FALSE)
+      stop("No valid position defined in '.after'.", call. = FALSE)
     }
   }
 
@@ -88,19 +104,19 @@ data_relocate <- function(data,
   position <- which(data_cols %in% cols)
 
   # Find new positions
-  if (!is.null(before)) {
-    before <- before[before %in% data_cols][1] # Take first that exists (if vector is supplied)
-    if (length(before) != 1) {
-      stop("The column passed to 'before' wasn't found. Possibly mispelled.")
+  if (!is.null(.before)) {
+    .before <- .before[.before %in% data_cols][1] # Take first that exists (if vector is supplied)
+    if (length(.before) != 1) {
+      stop("The column passed to '.before' wasn't found. Possibly mispelled.")
     }
-    where <- min(match(before, data_cols))
+    where <- min(match(.before, data_cols))
     position <- c(setdiff(position, where), where)
-  } else if (!is.null(after)) {
-    after <- after[after %in% data_cols][1] # Take first that exists (if vector is supplied)
-    if (length(after) != 1) {
-      stop("The column passed to 'after' wasn't found. Possibly mispelled.")
+  } else if (!is.null(.after)) {
+    .after <- .after[.after %in% data_cols][1] # Take first that exists (if vector is supplied)
+    if (length(.after) != 1) {
+      stop("The column passed to '.after' wasn't found. Possibly mispelled.")
     }
-    where <- max(match(after, data_cols))
+    where <- max(match(.after, data_cols))
     position <- c(where, setdiff(position, where))
   } else {
     where <- 1

--- a/R/data_reshape.R
+++ b/R/data_reshape.R
@@ -324,7 +324,7 @@ data_to_wide <- function(data,
       wide <- data_relocate(
         wide,
         select = grep(paste0("^", i), names(wide), value = TRUE),
-        after = -1
+        .after = -1
       )
     }
   }

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -9,11 +9,13 @@
 data_relocate(
   data,
   select,
-  before = NULL,
-  after = NULL,
+  .before = NULL,
+  .after = NULL,
   ignore_case = FALSE,
   verbose = TRUE,
-  ...
+  ...,
+  before,
+  after
 )
 
 data_reorder(data, select, ignore_case = FALSE, verbose = TRUE, ...)
@@ -53,7 +55,7 @@ If \code{NULL}, selects all columns. Patterns that found no matches are silently
 ignored, e.g. \code{find_columns(iris, select = c("Species", "Test"))} will just
 return \code{"Species"}.}
 
-\item{before, after}{Destination of columns. Supplying neither will move
+\item{.before, .after}{Destination of columns. Supplying neither will move
 columns to the left-hand side; specifying both is an error. Can be a
 character vector, indicating the name of the destination column, or a
 numeric value, indicating the index number of the destination column.
@@ -66,6 +68,8 @@ search pattern when matching against variable names.}
 \item{verbose}{Toggle warnings.}
 
 \item{...}{Arguments passed down to other functions. Mostly not used yet.}
+
+\item{before, after}{Deprecated. Please use \code{.before} and \code{.after} instead.}
 }
 \value{
 A data frame with reordered columns.

--- a/tests/testthat/test-data_relocate.R
+++ b/tests/testthat/test-data_relocate.R
@@ -1,36 +1,36 @@
 test_that("data_relocate works as expected", {
   expect_error(
-    data_relocate(iris, select = "Species", before = 2, after = 3),
-    "You must supply only one of `before` or `after`."
+    data_relocate(iris, select = "Species", .before = 2, .after = 3),
+    "You must supply only one of `.before` or `.after`."
   )
 
   expect_error(
-    data_relocate(iris, select = "Species", before = 10),
-    "No valid position defined in 'before'."
+    data_relocate(iris, select = "Species", .before = 10),
+    "No valid position defined in '.before'."
   )
 
   expect_error(
-    data_relocate(iris, select = "Species", after = 10),
-    "No valid position defined in 'after'."
+    data_relocate(iris, select = "Species", .after = 10),
+    "No valid position defined in '.after'."
   )
 
   expect_equal(
-    names(data_relocate(iris, select = "Species", before = "Sepal.Length")),
+    names(data_relocate(iris, select = "Species", .before = "Sepal.Length")),
     c("Species", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
   )
   expect_equal(
-    names(data_relocate(iris, select = "Species", before = "Sepal.Width")),
+    names(data_relocate(iris, select = "Species", .before = "Sepal.Width")),
     c("Sepal.Length", "Species", "Sepal.Width", "Petal.Length", "Petal.Width")
   )
 
   expect_equal(
-    names(data_relocate(iris, select = "Sepal.Width", after = "Species")),
-    names(data_relocate(iris, select = "Sepal.Width", after = -1))
+    names(data_relocate(iris, select = "Sepal.Width", .after = "Species")),
+    names(data_relocate(iris, select = "Sepal.Width", .after = -1))
   )
 
   expect_equal(
-    names(data_relocate(iris, select = c("Species", "Petal.Length"), after = "Sepal.Width")),
-    names(data_relocate(iris, select = c("Species", "Petal.Length"), after = 2))
+    names(data_relocate(iris, select = c("Species", "Petal.Length"), .after = "Sepal.Width")),
+    names(data_relocate(iris, select = c("Species", "Petal.Length"), .after = 2))
   )
 })
 
@@ -38,11 +38,11 @@ test_that("data_relocate works as expected", {
 
 test_that("data_relocate select-helpers", {
   expect_equal(
-    colnames(data_relocate(iris, select = starts_with("Sepal"), after = 5)),
+    colnames(data_relocate(iris, select = starts_with("Sepal"), .after = 5)),
     colnames(iris[c(3:5, 1:2)])
   )
   expect_equal(
-    colnames(data_relocate(iris, select = 1:2, after = 5)),
+    colnames(data_relocate(iris, select = 1:2, .after = 5)),
     colnames(iris[c(3:5, 1:2)])
   )
   expect_equal(
@@ -50,7 +50,7 @@ test_that("data_relocate select-helpers", {
     colnames(iris[c(5, 1:4)])
   )
   expect_equal(
-    colnames(data_relocate(iris, select = Species, after = 1)),
+    colnames(data_relocate(iris, select = Species, .after = 1)),
     colnames(iris[c(1, 5, 2:4)])
   )
   expect_equal(
@@ -58,11 +58,11 @@ test_that("data_relocate select-helpers", {
     colnames(iris[c(2, 5, 1, 3:4)])
   )
   expect_equal(
-    colnames(data_relocate(iris, select = starts_with("sepal"), after = 5)),
+    colnames(data_relocate(iris, select = starts_with("sepal"), .after = 5)),
     colnames(iris)
   )
   expect_equal(
-    colnames(data_relocate(iris, select = starts_with("sepal"), after = 5, ignore_case = TRUE)),
+    colnames(data_relocate(iris, select = starts_with("sepal"), .after = 5, ignore_case = TRUE)),
     colnames(iris[c(3:5, 1:2)])
   )
 })


### PR DESCRIPTION
This PR deprecates `before` and `after` in `data_relocate()` to use `.before` and `.after` instead, like in `dplyr::relocate()`.