### PR TITLE
Improve speed of reshape_longer with names_sep

### DIFF
--- a/R/data_reshape.R
+++ b/R/data_reshape.R
@@ -183,7 +183,7 @@ data_to_long <- function(data,
     for (i in seq_along(names_to)) {
       if (is.null(names_pattern)) {
         new_vals <- unlist(lapply(
-          strsplit(long[[names_to_2]], names_sep, fixed = TRUE),
+          strsplit(unique(long[[names_to_2]]), names_sep, fixed = TRUE),
           function(x) x[i])
         )
         long[[names_to[i]]] <- new_vals


### PR DESCRIPTION
Before:
``` r
library(tidyr)
library(datawizard)

bench::mark(
  tidyr = who |> 
    pivot_longer(
      cols = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_sep = "_",
      values_to = "count"
    ) |>
    suppressWarnings(),
  datawizard = who %>% 
    reshape_longer(
      select = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_sep = "_",
      values_to = "count"
    )
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tidyr       25.86ms   33.7ms    27.7      40.8MB    20.3 
#> 2 datawizard    2.91s    2.91s     0.344   325.6MB     6.53
```

<sup>Created on 2022-07-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
After: 
```r
bench::mark(
  tidyr = who |> 
    pivot_longer(
      cols = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_sep = "_",
      values_to = "count"
    ),
  datawizard = who %>% 
    reshape_longer(
      select = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_sep = "_",
      values_to = "count"
    )
)

#> # A tibble: 2 × 13
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` 
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> 
#> 1 tidyr        25.8ms   27.3ms     25.0       33MB     8.92      
#> 2 datawizard  956.1ms  956.1ms      1.05     321MB     2.09    

```