### PR TITLE
`convert_na_to` improvements when dealing with character

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(
     person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = "aut",
            comment = c(ORCID = "0000-0002-9271-5075")),
     person("Rémi", "Thériault", , "remi.theriault@mail.mcgill.ca", role = "ctb",
-           comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")),
+           comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc"))
   )
 Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
 Description: A lightweight package to easily manipulate, clean, transform,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,9 @@ Authors@R: c(
     person("Brenton M.", "Wiernik", , "brenton@wiernik.org", role = "aut",
            comment = c(ORCID = "0000-0001-9560-6336", Twitter = "@bmwiernik")),
     person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = "aut",
-           comment = c(ORCID = "0000-0002-9271-5075"))
+           comment = c(ORCID = "0000-0002-9271-5075")),
+    person("Rémi", "Thériault", , "remi.theriault@mail.mcgill.ca", role = "ctb",
+           comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")),
   )
 Maintainer: Indrajeet Patil <patilindrajeet.science@gmail.com>
 Description: A lightweight package to easily manipulate, clean, transform,

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,9 @@ CHANGES
   `method = "zscore"`, winsorizes via the median and median absolute deviation
   (MAD); else via the mean and standard deviation. (@rempsyc, #177, #49, #47).
 
+* `convert_na_to` now accepts numeric replacements on character vectors and
+  single replacement for multiple vector classes. (@rempsyc, #214).
+  
 * `data_partition()` now allows to create multiple partitions from the data,
   returning multiple training and a remaining test set.
 

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -120,7 +120,7 @@ convert_na_to.factor <- function(x, replacement = NULL, verbose = TRUE, ...) {
 #' @rdname convert_na_to
 #' @export
 convert_na_to.character <- function(x, replacement = NULL, verbose = TRUE, ...) {
-  if (is_empty_object(replacement) || !is.character(replacement) & !is.numeric(replacement)) {
+  if (is_empty_object(replacement) || !is.character(replacement) && !is.numeric(replacement)) {
     if (isTRUE(verbose)) {
       warning(insight::format_message(
         "`replacement` needs to be a character or numeric vector."), call. = FALSE)

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -120,16 +120,17 @@ convert_na_to.factor <- function(x, replacement = NULL, verbose = TRUE, ...) {
 #' @rdname convert_na_to
 #' @export
 convert_na_to.character <- function(x, replacement = NULL, verbose = TRUE, ...) {
-  if (is_empty_object(replacement) || !is.character(replacement)) {
+  if (is_empty_object(replacement) || !is.character(replacement) & !is.numeric(replacement)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`replacement` needs to be a character vector."), call. = FALSE)
+      warning(insight::format_message(
+        "`replacement` needs to be a character or numeric vector."), call. = FALSE)
     }
   } else if (length(replacement) > 1) {
     if (isTRUE(verbose)) {
       warning(insight::format_message("`replacement` needs to be of length one."), call. = FALSE)
     }
   } else {
-    x[is.na(x)] <- replacement
+    x[is.na(x)] <- as.character(replacement)
   }
   x
 }
@@ -145,9 +146,10 @@ convert_na_to.character <- function(x, replacement = NULL, verbose = TRUE, ...) 
 convert_na_to.data.frame <- function(x,
                                      select = NULL,
                                      exclude = NULL,
-                                     replace_num = NULL,
-                                     replace_char = NULL,
-                                     replace_fac = NULL,
+                                     replacement = NULL,
+                                     replace_num = replacement,
+                                     replace_char = replacement,
+                                     replace_fac = replacement,
                                      ignore_case = FALSE,
                                      verbose = TRUE,
                                      ...) {
@@ -201,7 +203,7 @@ convert_na_to.data.frame <- function(x,
     if (is.numeric(x)) {
       repl <- replace_num
     } else if (is.character(x)) {
-      repl <- replace_char
+      repl <- as.character(replace_char)
     } else if (is.factor(x)) {
       repl <- replace_fac
     }

--- a/man/convert_na_to.Rd
+++ b/man/convert_na_to.Rd
@@ -17,9 +17,10 @@ convert_na_to(x, ...)
   x,
   select = NULL,
   exclude = NULL,
-  replace_num = NULL,
-  replace_char = NULL,
-  replace_fac = NULL,
+  replacement = NULL,
+  replace_num = replacement,
+  replace_char = replacement,
+  replace_fac = replacement,
   ignore_case = FALSE,
   verbose = TRUE,
   ...

--- a/tests/testthat/test-convert_na_to.R
+++ b/tests/testthat/test-convert_na_to.R
@@ -59,12 +59,12 @@ test_that("convert_na_to - character: works", {
 
 test_that("convert_na_to - character: arg 'replacement' can only be character", {
   expect_warning(
-    convert_na_to(c("a", "b", "c", NA), replacement = 1),
-    regexp = "`replacement` needs to be a character vector."
+    convert_na_to(c("a", "b", "c", NA), replacement = mtcars),
+    regexp = "`replacement` needs to be a character or numeric vector."
   )
   expect_warning(
     convert_na_to(c("a", "b", "c", NA), replacement = factor(8)),
-    regexp = "`replacement` needs to be a character vector."
+    regexp = "`replacement` needs to be a character or numeric vector."
   )
 })
 
@@ -77,7 +77,7 @@ test_that("convert_na_to - numeric: arg 'replacement' must be of length one", {
 
 test_that("convert_na_to - character: returns original vector if 'replacement' not good", {
   expect_equal(
-    convert_na_to(c("a", "b", "c", NA), replacement = 1, verbose = FALSE),
+    convert_na_to(c("a", "b", "c", NA), replacement = mtcars, verbose = FALSE),
     c("a", "b", "c", NA)
   )
   expect_equal(

--- a/tests/testthat/test-convert_na_to.R
+++ b/tests/testthat/test-convert_na_to.R
@@ -77,6 +77,10 @@ test_that("convert_na_to - numeric: arg 'replacement' must be of length one", {
 
 test_that("convert_na_to - character: returns original vector if 'replacement' not good", {
   expect_equal(
+    convert_na_to(c("a", "b", "c", NA), replacement = 1, verbose = FALSE),
+    c("a", "b", "c", 1)
+  )
+  expect_equal(
     convert_na_to(c("a", "b", "c", NA), replacement = mtcars, verbose = FALSE),
     c("a", "b", "c", NA)
   )


### PR DESCRIPTION
Closes #214 
``` r
devtools::load_all("D:/OneDrive - UQAM/GitHub/forks/datawizard")
#> ℹ Loading datawizard
df <- data.frame(letters, numbers = 1:26, factors = as.factor(letters))[1:5,]
df[2:3,] <- NA
df
#>   letters numbers factors
#> 1       a       1       a
#> 2    <NA>      NA    <NA>
#> 3    <NA>      NA    <NA>
#> 4       d       4       d
#> 5       e       5       e

# Now works as expected for numeric replacements on character vectors
convert_na_to(df$letters, replacement = 0)
#> [1] "a" "0" "0" "d" "e"
convert_na_to(df, replace_num = 0,
              replace_char = 0,
              replace_fac = 0)
#>   letters numbers factors
#> 1       a       1       a
#> 2       0       0       0
#> 3       0       0       0
#> 4       d       4       d
#> 5       e       5       e

# Now works as expected when specifying a single replacement for multiple vector classes
convert_na_to(df, replacement = 0)
#>   letters numbers factors
#> 1       a       1       a
#> 2       0       0       0
#> 3       0       0       0
#> 4       d       4       d
#> 5       e       5       e

# It is possible to overwrite the global replacement if needed
convert_na_to(df, replacement = 0,
              replace_num = 7,
              replace_char = "Missing",
              replace_fac = "Factor")
#>   letters numbers factors
#> 1       a       1       a
#> 2 Missing       7  Factor
#> 3 Missing       7  Factor
#> 4       d       4       d
#> 5       e       5       e
```
<sup>Created on 2022-08-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
I have updated tests accordingly.