### PR TITLE
add regex argument to all functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@ BREAKING CHANGES
 * New `text_format()` alias is introduced for `format_text()`, latter of which
   will be removed in the next release.
 
+CHANGES
+
+* The `regex` argument was added to functions that use select-helpers and did
+  not already have this argument.
+
 # datawizard 0.5.1
 
 * Fixes failing tests due to `{poorman}` update.

--- a/R/adjust.R
+++ b/R/adjust.R
@@ -103,7 +103,7 @@ adjust <- function(data,
                           exclude,
                           ignore_case,
                           regex = regex,
-                          verbose = FALSE)
+                          verbose = verbose)
   }
 
   # Factors

--- a/R/adjust.R
+++ b/R/adjust.R
@@ -72,7 +72,9 @@ adjust <- function(data,
                    additive = FALSE,
                    bayesian = FALSE,
                    keep_intercept = FALSE,
-                   ignore_case = FALSE) {
+                   ignore_case = FALSE,
+                   regex = FALSE,
+                   verbose = FALSE) {
   if (!all(colnames(data) == make.names(colnames(data), unique = TRUE))) {
     warning(insight::format_message(
       "Bad column names (e.g., with spaces) have been detected which might create issues in many functions.",
@@ -96,7 +98,12 @@ adjust <- function(data,
     select <- names(data[nums])
   } else {
     # evaluate select/exclude, may be select-helpers
-    select <- .select_nse(select, data, exclude, ignore_case, verbose = FALSE)
+    select <- .select_nse(select,
+                          data,
+                          exclude,
+                          ignore_case,
+                          regex = regex,
+                          verbose = FALSE)
   }
 
   # Factors

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -262,7 +262,7 @@ categorize.data.frame <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(
@@ -319,7 +319,7 @@ categorize.grouped_df <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(x, select, exclude, weights = NULL, append, append_suffix = "_r", force = TRUE)

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -253,10 +253,16 @@ categorize.data.frame <- function(x,
                                   labels = NULL,
                                   append = FALSE,
                                   ignore_case = FALSE,
+                                  regex = FALSE,
                                   verbose = TRUE,
                                   ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # process arguments
   args <- .process_std_args(
@@ -299,6 +305,7 @@ categorize.grouped_df <- function(x,
                                   labels = NULL,
                                   append = FALSE,
                                   ignore_case = FALSE,
+                                  regex = FALSE,
                                   verbose = TRUE,
                                   ...) {
   info <- attributes(x)
@@ -307,7 +314,12 @@ categorize.grouped_df <- function(x,
   grps <- attr(x, "groups", exact = TRUE)
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # process arguments
   args <- .process_std_args(x, select, exclude, weights = NULL, append, append_suffix = "_r", force = TRUE)

--- a/R/center.R
+++ b/R/center.R
@@ -171,9 +171,15 @@ center.data.frame <- function(x,
                               append = FALSE,
                               ignore_case = FALSE,
                               verbose = TRUE,
+                              regex = FALSE,
                               ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(x, select, exclude, weights, append,
@@ -217,9 +223,15 @@ center.grouped_df <- function(x,
                               append = FALSE,
                               ignore_case = FALSE,
                               verbose = TRUE,
+                              regex = FALSE,
                               ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   args <- .process_grouped_df(x, select, exclude, append,
     append_suffix = "_c",

--- a/R/change_code.R
+++ b/R/change_code.R
@@ -454,10 +454,16 @@ change_code.data.frame <- function(x,
                                    preserve_na = TRUE,
                                    append = FALSE,
                                    ignore_case = FALSE,
+                                   regex = FALSE,
                                    verbose = TRUE,
                                    ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(x, select, exclude, weights = NULL, append, append_suffix = "_r", force = TRUE)

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -154,10 +154,16 @@ convert_na_to.data.frame <- function(x,
                                      replace_char = replacement,
                                      replace_fac = replacement,
                                      ignore_case = FALSE,
+                                     regex = FALSE,
                                      verbose = TRUE,
                                      ...) {
   data <- x
-  select_nse <- .select_nse(select, data, exclude = exclude, ignore_case)
+  select_nse <- .select_nse(select,
+                            data,
+                            exclude = exclude,
+                            ignore_case,
+                            regex = regex,
+                            verbose = verbose)
 
   # list are not covered by .select_nse
   if (length(select_nse) == 0) {

--- a/R/convert_to_na.R
+++ b/R/convert_to_na.R
@@ -168,10 +168,16 @@ convert_to_na.data.frame <- function(x,
                                      na = NULL,
                                      drop_levels = FALSE,
                                      ignore_case = FALSE,
+                                     regex = FALSE,
                                      verbose = TRUE,
                                      ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   x[select] <- lapply(x[select], convert_to_na, na = na, drop_levels = drop_levels, verbose = verbose, ...)
   x

--- a/R/data_extract.R
+++ b/R/data_extract.R
@@ -79,12 +79,18 @@ data_extract.data.frame <- function(data,
                                     extract = "all",
                                     as_data_frame = FALSE,
                                     ignore_case = FALSE,
+                                    regex = FALSE,
                                     verbose = TRUE,
                                     ...) {
   extract <- match.arg(tolower(extract), choices = c("all", "first", "last", "odd", "even"))
 
   # evaluate arguments
-  select <- .select_nse(select, data, exclude = NULL, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        data,
+                        exclude = NULL,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # nothing to select?
   if (!length(select)) {

--- a/R/data_group.R
+++ b/R/data_group.R
@@ -5,7 +5,7 @@
 #' following the **datawizard** function design. `data_ungroup()` removes the
 #' grouping information from a grouped data frame.
 #'
-#' @param x A data frame
+#' @param data A data frame
 #' @inheritParams find_columns
 #'
 #' @return A grouped data frame, i.e. a data frame with additional information
@@ -26,22 +26,29 @@
 #'     summarize(mean_hours = mean(c12hour, na.rm = TRUE))
 #' }
 #' @export
-data_group <- function(x,
+data_group <- function(data,
                        select = NULL,
                        exclude = NULL,
                        ignore_case = FALSE,
+                       regex = FALSE,
                        verbose = TRUE,
                        ...) {
   # variables for grouping
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(
+    select,
+    data,
+    exclude,
+    ignore_case = ignore_case,
+    regex = regex,
+    verbose = verbose)
   # create grid with combinations of all levels
-  grid <- as.data.frame(expand.grid(lapply(x[select], unique)))
+  grid <- as.data.frame(expand.grid(lapply(data[select], unique)))
   # sort grid
   grid <- grid[do.call(order, grid), , drop = FALSE]
 
   .rows <- lapply(seq_len(nrow(grid)), function(i) {
     as.integer(data_match(
-      x,
+      data,
       to = grid[i, , drop = FALSE],
       match = "and",
       return_indices = TRUE,
@@ -54,20 +61,20 @@ data_group <- function(x,
   attr(grid, "out.attrs") <- NULL
   attr(grid, ".drop") <- TRUE
 
-  attr(x, "groups") <- grid
-  class(x) <- unique(c("grouped_df", "data.frame"), class(x))
+  attr(data, "groups") <- grid
+  class(data) <- unique(c("grouped_df", "data.frame"), class(data))
 
-  x
+  data
 }
 
 
 #' @rdname data_group
 #' @export
-data_ungroup <- function(x,
+data_ungroup <- function(data,
                          verbose = TRUE,
                          ...) {
-  attr(x, "groups") <- NULL
-  class(x) <- unique(setdiff(class(x), "grouped_df"))
+  attr(data, "groups") <- NULL
+  class(data) <- unique(setdiff(class(data), "grouped_df"))
 
-  x
+  data
 }

--- a/R/data_relocate.R
+++ b/R/data_relocate.R
@@ -45,6 +45,7 @@ data_relocate <- function(data,
                           before = NULL,
                           after = NULL,
                           ignore_case = FALSE,
+                          regex = FALSE,
                           verbose = TRUE,
                           ...) {
   # Sanitize
@@ -74,7 +75,12 @@ data_relocate <- function(data,
     }
   }
 
-  cols <- .select_nse(select, data, exclude = NULL, ignore_case = ignore_case, verbose = verbose)
+  cols <- .select_nse(select,
+                      data,
+                      exclude = NULL,
+                      ignore_case = ignore_case,
+                      regex = regex,
+                      verbose = verbose)
 
   # save attributes
   att <- attributes(data)
@@ -122,8 +128,19 @@ data_relocate <- function(data,
 
 #' @rdname data_relocate
 #' @export
-data_reorder <- function(data, select, ignore_case = FALSE, verbose = TRUE, ...) {
-  cols <- .select_nse(select, data, exclude = NULL, ignore_case = ignore_case, verbose = verbose)
+data_reorder <- function(data,
+                         select,
+                         exclude = NULL,
+                         ignore_case = FALSE,
+                         regex = FALSE,
+                         verbose = TRUE,
+                         ...) {
+  cols <- .select_nse(select,
+                      data,
+                      exclude = NULL,
+                      ignore_case = ignore_case,
+                      regex = regex,
+                      verbose = verbose)
   remaining_columns <- setdiff(colnames(data), cols)
 
   out <- data[c(cols, remaining_columns)]

--- a/R/data_remove.R
+++ b/R/data_remove.R
@@ -21,7 +21,7 @@ data_remove <- function(data,
     exclude = NULL,
     ignore_case = ignore_case,
     regex = regex,
-    verbose = FALSE)
+    verbose = verbose)
 
   # nothing to remove?
   if (!length(select)) {

--- a/R/data_remove.R
+++ b/R/data_remove.R
@@ -5,11 +5,23 @@
 #' head(data_remove(iris, "Sepal.Length"))
 #' head(data_remove(iris, starts_with("Sepal")))
 #' @export
-data_remove <- function(data, select, ignore_case = FALSE, verbose = FALSE, ...) {
+data_remove <- function(data,
+                        select = NULL,
+                        exclude = NULL,
+                        ignore_case = FALSE,
+                        regex = FALSE,
+                        verbose = FALSE,
+                        ...) {
   ## TODO set verbose = TRUE by default in a later update?
 
   # evaluate arguments
-  select <- .select_nse(select, data, exclude = NULL, ignore_case)
+  select <- .select_nse(
+    select,
+    data,
+    exclude = NULL,
+    ignore_case = ignore_case,
+    regex = regex,
+    verbose = FALSE)
 
   # nothing to remove?
   if (!length(select)) {

--- a/R/data_rescale.R
+++ b/R/data_rescale.R
@@ -134,7 +134,7 @@ rescale.grouped_df <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {
@@ -179,7 +179,7 @@ rescale.data.frame <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # Transform the range so that it is a list now
   if (!is.null(range)) {

--- a/R/data_rescale.R
+++ b/R/data_rescale.R
@@ -120,6 +120,8 @@ rescale.grouped_df <- function(x,
                                to = c(0, 100),
                                range = NULL,
                                ignore_case = FALSE,
+                               regex = FALSE,
+                               verbose = FALSE,
                                ...) {
   info <- attributes(x)
 
@@ -127,7 +129,12 @@ rescale.grouped_df <- function(x,
   grps <- attr(x, "groups", exact = TRUE)
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {
@@ -163,9 +170,16 @@ rescale.data.frame <- function(x,
                                to = c(0, 100),
                                range = NULL,
                                ignore_case = FALSE,
+                               regex = FALSE,
+                               verbose = FALSE,
                                ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # Transform the range so that it is a list now
   if (!is.null(range)) {

--- a/R/data_reverse.R
+++ b/R/data_reverse.R
@@ -145,7 +145,7 @@ reverse.grouped_df <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {
@@ -188,7 +188,7 @@ reverse.data.frame <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # Transform the range so that it is a list now
   if (!is.null(range)) {

--- a/R/data_reverse.R
+++ b/R/data_reverse.R
@@ -131,6 +131,8 @@ reverse.grouped_df <- function(x,
                                exclude = NULL,
                                range = NULL,
                                ignore_case = FALSE,
+                               regex = FALSE,
+                               verbose = FALSE,
                                ...) {
   info <- attributes(x)
 
@@ -138,7 +140,12 @@ reverse.grouped_df <- function(x,
   grps <- attr(x, "groups", exact = TRUE)
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {
@@ -172,9 +179,16 @@ reverse.data.frame <- function(x,
                                exclude = NULL,
                                range = NULL,
                                ignore_case = FALSE,
+                               regex = FALSE,
+                               verbose = FALSE,
                                ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # Transform the range so that it is a list now
   if (!is.null(range)) {

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -130,12 +130,18 @@ data_tabulate.data.frame <- function(x,
                                      select = NULL,
                                      exclude = NULL,
                                      ignore_case = FALSE,
+                                     regex = FALSE,
                                      collapse = FALSE,
                                      drop_levels = FALSE,
                                      verbose = TRUE,
                                      ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
   out <- lapply(select, function(i) {
     data_tabulate(x[[i]], drop_levels = drop_levels, name = i, verbose = verbose, ...)
   })
@@ -152,6 +158,7 @@ data_tabulate.grouped_df <- function(x,
                                      select = NULL,
                                      exclude = NULL,
                                      ignore_case = FALSE,
+                                     regex = FALSE,
                                      verbose = TRUE,
                                      collapse = FALSE,
                                      drop_levels = FALSE,
@@ -161,7 +168,12 @@ data_tabulate.grouped_df <- function(x,
   group_variables <- NULL
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = FALSE)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -141,7 +141,7 @@ data_tabulate.data.frame <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
   out <- lapply(select, function(i) {
     data_tabulate(x[[i]], drop_levels = drop_levels, name = i, verbose = verbose, ...)
   })
@@ -173,7 +173,7 @@ data_tabulate.grouped_df <- function(x,
                         exclude,
                         ignore_case,
                         regex = regex,
-                        verbose = FALSE)
+                        verbose = verbose)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -375,9 +375,15 @@ describe_distribution.data.frame <- function(x,
                                              iterations = 100,
                                              threshold = .1,
                                              ignore_case = FALSE,
+                                             regex = FALSE,
                                              verbose = TRUE,
                                              ...) {
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
   # The function currently doesn't support descriptive summaries for character
   # or factor types.
   out <- do.call(rbind, lapply(x[select], function(i) {
@@ -424,12 +430,18 @@ describe_distribution.grouped_df <- function(x,
                                              iterations = 100,
                                              threshold = .1,
                                              ignore_case = FALSE,
+                                             regex = FALSE,
                                              verbose = TRUE,
                                              ...) {
   group_vars <- setdiff(colnames(attributes(x)$groups), ".rows")
   group_data <- expand.grid(lapply(x[group_vars], function(i) unique(sort(i))))
   groups <- split(x, x[group_vars])
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   out <- do.call(rbind, lapply(1:length(groups), function(i) {
     d <- describe_distribution.data.frame(

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -119,10 +119,16 @@ normalize.grouped_df <- function(x,
                                  exclude = NULL,
                                  include_bounds = TRUE,
                                  ignore_case = FALSE,
+                                 regex = FALSE,
                                  verbose = TRUE,
                                  ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   info <- attributes(x)
   # dplyr >= 0.8.0 returns attribute "indices"
@@ -168,10 +174,16 @@ normalize.data.frame <- function(x,
                                  exclude = NULL,
                                  include_bounds = TRUE,
                                  ignore_case = FALSE,
+                                 regex = FALSE,
                                  verbose = TRUE,
                                  ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
   x[select] <- lapply(x[select], normalize, include_bounds = include_bounds, verbose = verbose)
 
   x

--- a/R/ranktransform.R
+++ b/R/ranktransform.R
@@ -104,13 +104,20 @@ ranktransform.grouped_df <- function(x,
                                      sign = FALSE,
                                      method = "average",
                                      ignore_case = FALSE,
+                                     regex = FALSE,
+                                     verbose = TRUE,
                                      ...) {
   info <- attributes(x)
   # dplyr >= 0.8.0 returns attribute "indices"
   grps <- attr(x, "groups", exact = TRUE)
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # dplyr < 0.8.0?
   if (is.null(grps)) {
@@ -145,9 +152,16 @@ ranktransform.data.frame <- function(x,
                                      sign = FALSE,
                                      method = "average",
                                      ignore_case = FALSE,
+                                     regex = FALSE,
+                                     verbose = TRUE,
                                      ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   x[select] <- lapply(x[select], ranktransform, sign = sign, method = method)
   x

--- a/R/slide.R
+++ b/R/slide.R
@@ -62,10 +62,16 @@ slide.data.frame <- function(x,
                              lowest = 0,
                              append = FALSE,
                              ignore_case = FALSE,
+                             regex = FALSE,
                              verbose = TRUE,
                              ...) {
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -246,10 +246,16 @@ standardize.data.frame <- function(x,
                                    force = FALSE,
                                    append = FALSE,
                                    ignore_case = FALSE,
+                                   regex = FALSE,
                                    verbose = TRUE,
                                    ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # process arguments
   args <- .process_std_args(x, select, exclude, weights, append,
@@ -297,10 +303,16 @@ standardize.grouped_df <- function(x,
                                    force = FALSE,
                                    append = FALSE,
                                    ignore_case = FALSE,
+                                   regex = FALSE,
                                    verbose = TRUE,
                                    ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   args <- .process_grouped_df(x, select, exclude, append,
     append_suffix = "_z",

--- a/R/to_factor.R
+++ b/R/to_factor.R
@@ -83,6 +83,7 @@ to_factor.data.frame <- function(x,
                                  exclude = NULL,
                                  ignore_case = FALSE,
                                  append = FALSE,
+                                 regex = FALSE,
                                  verbose = TRUE,
                                  ...) {
   # sanity check, return as is for complete numeric
@@ -91,7 +92,12 @@ to_factor.data.frame <- function(x,
   }
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # drop factors, when append is not FALSE
   if (!isFALSE(append)) {

--- a/R/to_numeric.R
+++ b/R/to_numeric.R
@@ -61,6 +61,7 @@ to_numeric.data.frame <- function(x,
                                   lowest = NULL,
                                   append = FALSE,
                                   ignore_case = FALSE,
+                                  regex = FALSE,
                                   verbose = TRUE,
                                   ...) {
   # sanity check, return as is for complete numeric
@@ -69,7 +70,12 @@ to_numeric.data.frame <- function(x,
   }
 
   # evaluate arguments
-  select <- .select_nse(select, x, exclude, ignore_case)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   # drop numerics, when append is not FALSE
   if (!isFALSE(append)) {

--- a/R/unnormalize.R
+++ b/R/unnormalize.R
@@ -41,10 +41,16 @@ unnormalize.data.frame <- function(x,
                                    select = NULL,
                                    exclude = NULL,
                                    ignore_case = FALSE,
+                                   regex = FALSE,
                                    verbose = TRUE,
                                    ...) {
   # evaluate select/exclude, may be select-helpers
-  select <- .select_nse(select, x, exclude, ignore_case, verbose = verbose)
+  select <- .select_nse(select,
+                        x,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
   x[select] <- lapply(x[select], unnormalize, verbose = verbose)
 
   x

--- a/man/adjust.Rd
+++ b/man/adjust.Rd
@@ -14,7 +14,9 @@ adjust(
   additive = FALSE,
   bayesian = FALSE,
   keep_intercept = FALSE,
-  ignore_case = FALSE
+  ignore_case = FALSE,
+  regex = FALSE,
+  verbose = FALSE
 )
 
 data_adjust(
@@ -26,7 +28,9 @@ data_adjust(
   additive = FALSE,
   bayesian = FALSE,
   keep_intercept = FALSE,
-  ignore_case = FALSE
+  ignore_case = FALSE,
+  regex = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -88,6 +92,17 @@ visual representation of this).}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
+
+\item{verbose}{Toggle warnings.}
 }
 \value{
 A data frame comparable to \code{data}, with adjusted variables.

--- a/man/categorize.Rd
+++ b/man/categorize.Rd
@@ -30,6 +30,7 @@ categorize(x, ...)
   labels = NULL,
   append = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -119,6 +120,15 @@ the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 \code{x}, recoded into groups. By default \code{x} is numeric, unless \code{labels}

--- a/man/center.Rd
+++ b/man/center.Rd
@@ -34,6 +34,7 @@ centre(x, ...)
   append = FALSE,
   ignore_case = FALSE,
   verbose = TRUE,
+  regex = FALSE,
   ...
 )
 }
@@ -122,6 +123,15 @@ names (using the defined suffix) to the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 The centered variables.

--- a/man/change_code.Rd
+++ b/man/change_code.Rd
@@ -26,6 +26,7 @@ change_code(x, ...)
   preserve_na = TRUE,
   append = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -102,6 +103,15 @@ the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 \code{x}, where old values are replaced by new values.

--- a/man/convert_na_to.Rd
+++ b/man/convert_na_to.Rd
@@ -22,6 +22,7 @@ convert_na_to(x, ...)
   replace_char = replacement,
   replace_fac = replacement,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -79,6 +80,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 \code{x}, where \code{NA} values are replaced by \code{replacement}.

--- a/man/convert_to_na.Rd
+++ b/man/convert_to_na.Rd
@@ -20,6 +20,7 @@ convert_to_na(x, ...)
   na = NULL,
   drop_levels = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -76,6 +77,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 \code{x}, where all values in \code{na} are converted to \code{NA}.

--- a/man/data_extract.Rd
+++ b/man/data_extract.Rd
@@ -14,6 +14,7 @@ data_extract(data, select, ...)
   extract = "all",
   as_data_frame = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -77,6 +78,15 @@ or a data frame. See \code{extract} for details.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/man/data_group.Rd
+++ b/man/data_group.Rd
@@ -6,18 +6,19 @@
 \title{Create a grouped data frame}
 \usage{
 data_group(
-  x,
+  data,
   select = NULL,
   exclude = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
 
-data_ungroup(x, verbose = TRUE, ...)
+data_ungroup(data, verbose = TRUE, ...)
 }
 \arguments{
-\item{x}{A data frame}
+\item{data}{A data frame}
 
 \item{select}{Variables that will be included when performing the required
 tasks. Can be either
@@ -56,6 +57,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{verbose}{Toggle warnings.}
 

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -12,11 +12,20 @@ data_relocate(
   before = NULL,
   after = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
 
-data_reorder(data, select, ignore_case = FALSE, verbose = TRUE, ...)
+data_reorder(
+  data,
+  select,
+  exclude = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
+  verbose = TRUE,
+  ...
+)
 
 data_remove(
   data,
@@ -71,14 +80,6 @@ If \code{-1}, will be added before or after the last column.}
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
 
-\item{verbose}{Toggle warnings.}
-
-\item{...}{Arguments passed down to other functions. Mostly not used yet.}
-
-\item{exclude}{See \code{select}, however, column names matched by the pattern
-from \code{exclude} will be excluded instead of selected. If \code{NULL} (the default),
-excludes no columns.}
-
 \item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
 treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
 character string (or a variable containing a character string) and is not
@@ -87,6 +88,14 @@ of length > 1. \code{regex = TRUE} is comparable to using one of the two
 select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
 since the select-helpers may not work when called from inside other
 functions (see 'Details'), this argument may be used as workaround.}
+
+\item{verbose}{Toggle warnings.}
+
+\item{...}{Arguments passed down to other functions. Mostly not used yet.}
+
+\item{exclude}{See \code{select}, however, column names matched by the pattern
+from \code{exclude} will be excluded instead of selected. If \code{NULL} (the default),
+excludes no columns.}
 }
 \value{
 A data frame with reordered columns.

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -18,7 +18,15 @@ data_relocate(
 
 data_reorder(data, select, ignore_case = FALSE, verbose = TRUE, ...)
 
-data_remove(data, select, ignore_case = FALSE, verbose = FALSE, ...)
+data_remove(
+  data,
+  select = NULL,
+  exclude = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
+  verbose = FALSE,
+  ...
+)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -66,6 +74,19 @@ search pattern when matching against variable names.}
 \item{verbose}{Toggle warnings.}
 
 \item{...}{Arguments passed down to other functions. Mostly not used yet.}
+
+\item{exclude}{See \code{select}, however, column names matched by the pattern
+from \code{exclude} will be excluded instead of selected. If \code{NULL} (the default),
+excludes no columns.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A data frame with reordered columns.

--- a/man/data_tabulate.Rd
+++ b/man/data_tabulate.Rd
@@ -15,6 +15,7 @@ data_tabulate(x, ...)
   select = NULL,
   exclude = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
   collapse = FALSE,
   drop_levels = FALSE,
   verbose = TRUE,
@@ -72,6 +73,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{collapse}{Logical, if \code{TRUE} collapses multiple tables into one larger
 table for printing. This affects only printing, not the returned object.}

--- a/man/describe_distribution.Rd
+++ b/man/describe_distribution.Rd
@@ -39,6 +39,7 @@ describe_distribution(x, ...)
   iterations = 100,
   threshold = 0.1,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -115,6 +116,15 @@ well as n and missing will contain information.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A data frame with columns that describe the properties of the variables.

--- a/man/normalize.Rd
+++ b/man/normalize.Rd
@@ -19,6 +19,7 @@ normalize(x, ...)
   exclude = NULL,
   include_bounds = TRUE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -32,6 +33,7 @@ unnormalize(x, ...)
   select = NULL,
   exclude = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -86,6 +88,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A normalized object.

--- a/man/ranktransform.Rd
+++ b/man/ranktransform.Rd
@@ -17,6 +17,8 @@ ranktransform(x, ...)
   sign = FALSE,
   method = "average",
   ignore_case = FALSE,
+  regex = FALSE,
+  verbose = TRUE,
   ...
 )
 }
@@ -70,6 +72,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A rank-transformed object.

--- a/man/rescale.Rd
+++ b/man/rescale.Rd
@@ -20,6 +20,8 @@ change_scale(x, ...)
   to = c(0, 100),
   range = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
+  verbose = FALSE,
   ...
 )
 }
@@ -74,6 +76,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A rescaled object.

--- a/man/reverse.Rd
+++ b/man/reverse.Rd
@@ -19,6 +19,8 @@ reverse_scale(x, ...)
   exclude = NULL,
   range = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
+  verbose = FALSE,
   ...
 )
 }
@@ -69,6 +71,15 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 A reverse-scored object.

--- a/man/slide.Rd
+++ b/man/slide.Rd
@@ -17,6 +17,7 @@ slide(x, ...)
   lowest = 0,
   append = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -76,6 +77,15 @@ the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/man/standardize.Rd
+++ b/man/standardize.Rd
@@ -52,6 +52,7 @@ standardise(x, ...)
   force = FALSE,
   append = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -187,6 +188,15 @@ names (using the defined suffix) to the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 }
 \value{
 The standardized object (either a standardize data frame or a

--- a/man/to_factor.Rd
+++ b/man/to_factor.Rd
@@ -13,6 +13,7 @@ to_factor(x, ...)
   exclude = NULL,
   ignore_case = FALSE,
   append = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -69,6 +70,15 @@ based on the calling function: \code{"_r"} for recode functions, \code{"_n"} for
 overwritten by their recoded versions. If a character value, recoded
 variables are appended with new column names (using the defined suffix) to
 the original data frame.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/man/to_numeric.Rd
+++ b/man/to_numeric.Rd
@@ -16,6 +16,7 @@ to_numeric(x, ...)
   lowest = NULL,
   append = FALSE,
   ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -83,6 +84,15 @@ the original data frame.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/tests/testthat/test-adjust.R
+++ b/tests/testthat/test-adjust.R
@@ -22,5 +22,8 @@ test_that("adjust regex", {
   expect_equal(
     adjust(mtcars, select = "pg", regex = TRUE),
     adjust(mtcars, select = "mpg"))
+  expect_equal(
+    adjust(mtcars, select = "pg$", regex = TRUE),
+    adjust(mtcars, select = "mpg")
+  )
 })
-

--- a/tests/testthat/test-adjust.R
+++ b/tests/testthat/test-adjust.R
@@ -16,3 +16,11 @@ test_that("adjust", {
     tolerance = 1e-3
   )
 })
+
+# select helpers ------------------------------
+test_that("adjust regex", {
+  expect_equal(
+    adjust(mtcars, select = "pg", regex = TRUE),
+    adjust(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -132,4 +132,8 @@ test_that("center regex", {
   expect_equal(
     center(mtcars, select = "pg", regex = TRUE)$mpg,
     center(mtcars$mpg))
+  expect_equal(
+    center(mtcars, select = "pg$", regex = TRUE)$mpg,
+    center(mtcars$mpg)
+  )
 })

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -126,3 +126,10 @@ test_that("center, factors (grouped data)", {
 
   expect_equal(datawizard, manual)
 })
+
+# select helpers ------------------------------
+test_that("center regex", {
+  expect_equal(
+    center(mtcars, select = "pg", regex = TRUE)$mpg,
+    center(mtcars$mpg))
+})

--- a/tests/testthat/test-convert_na_to.R
+++ b/tests/testthat/test-convert_na_to.R
@@ -408,3 +408,11 @@ test_that("data_rename preserves attributes", {
 
   expect_equal(names(a1)[1:28], names(a2)[1:28])
 })
+
+# select helpers ------------------------------
+test_that("convert_na_to regex", {
+  expect_equal(
+    convert_na_to(airquality, replacement = 0, select = "zone", regex = TRUE),
+    convert_na_to(airquality, replacement = 0, select = "Ozone"))
+})
+

--- a/tests/testthat/test-convert_na_to.R
+++ b/tests/testthat/test-convert_na_to.R
@@ -414,5 +414,8 @@ test_that("convert_na_to regex", {
   expect_equal(
     convert_na_to(airquality, replacement = 0, select = "zone", regex = TRUE),
     convert_na_to(airquality, replacement = 0, select = "Ozone"))
+  expect_equal(
+    convert_na_to(airquality, replacement = 0, select = "zone$", regex = TRUE),
+    convert_na_to(airquality, replacement = 0, select = "Ozone")
+  )
 })
-

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -96,5 +96,8 @@ test_that("convert_to_na regex", {
   expect_equal(
     convert_to_na(mtcars, na = 4, select = "arb", regex = TRUE),
     convert_to_na(mtcars, na = 4, select = "carb"))
+  expect_equal(
+    convert_to_na(mtcars, na = 4, select = "arb$", regex = TRUE),
+    convert_to_na(mtcars, na = 4, select = "carb")
+  )
 })
-

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -90,3 +90,11 @@ test_that("convert_to_na other classes", {
   expect_message(x <- convert_to_na(d, na = list(3, "c", TRUE, "2022-01-02")))
   expect_equal(x, out, ignore_attr = TRUE, tolerance = 1e-3)
 })
+
+# select helpers ------------------------------
+test_that("convert_to_na regex", {
+  expect_equal(
+    convert_to_na(mtcars, na = 4, select = "arb", regex = TRUE),
+    convert_to_na(mtcars, na = 4, select = "carb"))
+})
+

--- a/tests/testthat/test-data_cut.R
+++ b/tests/testthat/test-data_cut.R
@@ -174,3 +174,11 @@ test_that("recode numeric", {
     )
   )
 })
+
+# select helpers ------------------------------
+test_that("categorize regex", {
+  expect_equal(
+    categorize(mtcars, select = "pg", regex = TRUE),
+    categorize(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-data_extract.R
+++ b/tests/testthat/test-data_extract.R
@@ -131,3 +131,11 @@ test_that("data_extract extract, pull", {
     c("Sepal.Length", "Sepal.Width", "Species")
   )
 })
+
+# select helpers ------------------------------
+test_that("data_extract regex", {
+  expect_equal(
+    data_extract(mtcars, select = "pg", regex = TRUE),
+    data_extract(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-data_extract.R
+++ b/tests/testthat/test-data_extract.R
@@ -137,5 +137,7 @@ test_that("data_extract regex", {
   expect_equal(
     data_extract(mtcars, select = "pg", regex = TRUE),
     data_extract(mtcars, select = "mpg"))
+  expect_equal(
+    data_extract(mtcars, select = "pg$", regex = TRUE),
+    data_extract(mtcars, select = "mpg"))
 })
-

--- a/tests/testthat/test-data_group.R
+++ b/tests/testthat/test-data_group.R
@@ -38,3 +38,11 @@ test_that("data_group attributes", {
     expect_equal(out$mw, c(87.125, 94.046875, 75), tolerance = 1e-3)
   }
 })
+
+# select helpers ------------------------------
+test_that("data_group regex", {
+  expect_equal(
+    attributes(data_group(mtcars, select = "yl", regex = TRUE))$groups[[1]],
+    sort(unique(mtcars$cyl)))
+})
+

--- a/tests/testthat/test-data_recode.R
+++ b/tests/testthat/test-data_recode.R
@@ -296,3 +296,12 @@ test_that("recode data.frame", {
     ignore_attr = TRUE
   )
 })
+
+# select helpers ------------------------------
+test_that("change_code regex", {
+  expect_equal(
+    change_code(iris, select = "ies", regex = TRUE, recode = list(
+      Group1 = "setosa", Group2 = "versicolor", Group3 = "virginica")),
+    change_code(iris, select = "Species", recode = list(
+      Group1 = "setosa", Group2 = "versicolor", Group3 = "virginica")))
+})

--- a/tests/testthat/test-data_relocate.R
+++ b/tests/testthat/test-data_relocate.R
@@ -82,3 +82,11 @@ test_that("data_relocate preserves attributes", {
 
   expect_equal(names(a1), names(a2))
 })
+
+# select helpers ------------------------------
+test_that("data_relocate regex", {
+  expect_equal(
+    names(data_relocate(mtcars, select = "pg", regex = TRUE, after = "carb"))[11],
+    "mpg")
+})
+

--- a/tests/testthat/test-data_remove.R
+++ b/tests/testthat/test-data_remove.R
@@ -119,3 +119,13 @@ test_that("data_remove preserves attributes", {
 
   expect_equal(names(a1), names(a2))
 })
+
+# select helpers ------------------------------
+test_that("data_remove regex", {
+  expect_equal(
+    names(data_remove(mtcars, select = "pg", regex = TRUE)),
+    names(mtcars[-(1)]))
+})
+
+
+

--- a/tests/testthat/test-data_rescale.R
+++ b/tests/testthat/test-data_rescale.R
@@ -61,3 +61,11 @@ test_that("rescale works with select helpers", {
     expect_equal(head(out$Petal.Length), head(iris$Petal.Length), tolerance = 1e-3)
   }
 })
+
+# select helpers ------------------------------
+test_that("data_rescale regex", {
+  expect_equal(
+    rescale(mtcars, select = "pg", regex = TRUE)$mpg,
+    rescale(mtcars, select = "mpg")$mpg)
+})
+

--- a/tests/testthat/test-data_reverse.R
+++ b/tests/testthat/test-data_reverse.R
@@ -382,3 +382,11 @@ test_that("reverse works with data frames containing NAs (grouped data)", {
     )
   )
 })
+
+# select helpers ------------------------------
+test_that("reverse regex", {
+  expect_equal(
+    reverse(mtcars, select = "arb", regex = TRUE),
+    reverse(mtcars, select = "carb"))
+})
+

--- a/tests/testthat/test-data_shift.R
+++ b/tests/testthat/test-data_shift.R
@@ -26,3 +26,11 @@ test_that("slide", {
   expect_equal(out$Species, iris$Species)
   expect_equal(range(out$Sepal.Length), c(0, 3.6), tolerance = 1e-2)
 })
+
+# select helpers ------------------------------
+test_that("slide regex", {
+  expect_equal(
+    slide(mtcars, select = "pg", regex = TRUE),
+    slide(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -310,3 +310,11 @@ if (requireNamespace("poorman", quietly = TRUE)) {
     })
   }
 }
+
+# select helpers ------------------------------
+test_that("data_tabulate regex", {
+  expect_equal(
+    data_tabulate(mtcars, select = "arb", regex = TRUE),
+    data_tabulate(mtcars, select = "carb"))
+})
+

--- a/tests/testthat/test-data_to_factor.R
+++ b/tests/testthat/test-data_to_factor.R
@@ -56,5 +56,8 @@ test_that("to_factor regex", {
   expect_equal(
     to_factor(mtcars, select = "yl", regex = TRUE),
     to_factor(mtcars, select = "cyl"))
+  expect_equal(
+    to_factor(mtcars, select = "yl$", regex = TRUE),
+    to_factor(mtcars, select = "cyl")
+  )
 })
-

--- a/tests/testthat/test-data_to_factor.R
+++ b/tests/testthat/test-data_to_factor.R
@@ -49,3 +49,12 @@ test_that("to_factor", {
   )
   expect_equal(sum(sapply(out, is.factor)), 3)
 })
+
+
+# select helpers ------------------------------
+test_that("to_factor regex", {
+  expect_equal(
+    to_factor(mtcars, select = "yl", regex = TRUE),
+    to_factor(mtcars, select = "cyl"))
+})
+

--- a/tests/testthat/test-data_to_numeric.R
+++ b/tests/testthat/test-data_to_numeric.R
@@ -146,3 +146,11 @@ test_that("convert factor to numeric, dummy factors, with NA", {
   expect_equal(nrow(to_numeric(x6, dummy_factors = TRUE)), length(x6))
   expect_equal(nrow(to_numeric(x7, dummy_factors = TRUE)), length(x7))
 })
+
+# select helpers ------------------------------
+test_that("to_numeric regex", {
+  expect_equal(
+    to_numeric(mtcars, select = "pg", regex = TRUE),
+    to_numeric(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -221,3 +221,11 @@ test_that("distribution_mode works as expected", {
   # empty
   expect_null(distribution_mode(c()))
 })
+
+# select helpers ------------------------------
+test_that("describe_distribution regex", {
+  expect_equal(
+    describe_distribution(mtcars, select = "pg", regex = TRUE),
+    describe_distribution(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-find_columns.R
+++ b/tests/testthat/test-find_columns.R
@@ -113,3 +113,11 @@ test_that("find_columns from other functions", {
   }
   expect_warning(expect_null(test_fun3(iris)))
 })
+
+# select helpers ------------------------------
+test_that("find_columns regex", {
+  expect_equal(
+    find_columns(mtcars, select = "pg", regex = TRUE),
+    find_columns(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -172,3 +172,11 @@ test_that("normalize, factor (grouped data)", {
 
   expect_equal(datawizard, manual)
 })
+
+# select helpers ------------------------------
+test_that("normalize regex", {
+  expect_equal(
+    normalize(mtcars, select = "pg", regex = TRUE),
+    normalize(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-ranktransform.R
+++ b/tests/testthat/test-ranktransform.R
@@ -108,3 +108,11 @@ test_that("ranktransform works with data frames containing NAs (grouped data)", 
     )
   )
 })
+
+# select helpers ------------------------------
+test_that("ranktransform regex", {
+  expect_equal(
+    ranktransform(mtcars, select = "pg", regex = TRUE),
+    ranktransform(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-standardize-data.R
+++ b/tests/testthat/test-standardize-data.R
@@ -237,3 +237,11 @@ test_that("unstandardize does nothing with characters and factors", {
     factor(c(1, 2))
   )
 })
+
+# select helpers ------------------------------
+test_that("standardize regex", {
+  expect_equal(
+    standardize(mtcars, select = "pg", regex = TRUE),
+    standardize(mtcars, select = "mpg"))
+})
+

--- a/tests/testthat/test-unnormalize.R
+++ b/tests/testthat/test-unnormalize.R
@@ -33,3 +33,12 @@ test_that("unnormalize and unstandardized x 4", {
   # attributes(z)
   expect_equal(unnormalize(z), x, ignore_attr = TRUE)
 })
+
+# select helpers ------------------------------
+test_that("unnormalize regex", {
+  x <- normalize(mtcars, select = "mpg")
+  expect_equal(
+    unnormalize(x, select = "pg", regex = TRUE),
+    unnormalize(x, select = "mpg"))
+})
+


### PR DESCRIPTION
Closes #229 

---
Before PR: 🙁
``` r
datawizard::data_remove(
  mtcars, select = "pg", regex = TRUE) |> names()
#>  [1] "mpg"  "cyl"  "disp" "hp"   "drat" "wt"   "qsec" "vs"   "am"   "gear"
#> [11] "carb"
```
After PR: 😀
``` r
datawizard::data_remove(
  mtcars, select = "pg", regex = TRUE) |> names()
#>  [1] "cyl"  "disp" "hp"   "drat" "wt"   "qsec" "vs"   "am"   "gear" "carb"
```
Also updated PR to update other `data_` functions (annnnnnnd added unit tests for them all):
- [x] `data_find` (find_columns)
- [x] `data_group`
- [x] `data_relocate`
- [x] `data_remove`
- [x] `data_rescale`
- [x] `data_reverse`
- [x] `data_tabulate`
- [x] `data_extract`

Annnnnnd on a whim I decided to check all other non-"_data" functions (why not!) and realized those too needed updating (annnnnnnd unit tests):
- [x] `adjust`
- [x] `categorize` (named `data_cut`?)
- [x] `center`
- [x] `change_code` (named `data_recode`; not sure if we should change_code/update those file names)
- [x] `convert_na_to`
- [x] `convert_to_na`
- [x] `describe_distribution`
- [x] `normalize`
- [x] `ranktransform`
- [x] `slide` (named `data_shift`?)
- [x] `standardize`
- [x] `to_factor`
- [x] `to_numeric`
- [x] `unnormalize`

Note also that I noticed discrepancies in the use of `verbose = TRUE` vs `FALSE` throughout but haven't touched those in case there is a reason for this. Edit: but saw this note:
> `## TODO set verbose = TRUE by default in a later update?## TODO set verbose = TRUE by default in a later update?`