### PR TITLE
add regex to `data_addprefix` for correct use in `performance::check_outliers`

### DIFF
--- a/R/data_addprefix.R
+++ b/R/data_addprefix.R
@@ -30,9 +30,21 @@ data_addprefix <- function(data,
 
 #' @rdname data_rename
 #' @export
-data_addsuffix <- function(data, pattern, select = NULL, exclude = NULL, ignore_case = FALSE, ...) {
+data_addsuffix <- function(data,
+                           pattern,
+                           select = NULL,
+                           exclude = NULL,
+                           ignore_case = FALSE,
+                           regex = FALSE,
+                           verbose = TRUE,
+                           ...) {
   # evaluate arguments
-  select <- .select_nse(select, data, exclude, ignore_case)
+  select <- .select_nse(select,
+                        data,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   selected_columns <- colnames(data) %in% select
   colnames(data)[selected_columns] <- paste0(colnames(data)[selected_columns], pattern)

--- a/R/data_addprefix.R
+++ b/R/data_addprefix.R
@@ -6,9 +6,21 @@
 #' head(data_addsuffix(iris, "_OLD"))
 #'
 #' @export
-data_addprefix <- function(data, pattern, select = NULL, exclude = NULL, ignore_case = FALSE, ...) {
+data_addprefix <- function(data,
+                           pattern,
+                           select = NULL,
+                           exclude = NULL,
+                           ignore_case = FALSE,
+                           regex = FALSE,
+                           verbose = TRUE,
+                           ...) {
   # evaluate arguments
-  select <- .select_nse(select, data, exclude, ignore_case)
+  select <- .select_nse(select,
+                        data,
+                        exclude,
+                        ignore_case,
+                        regex = regex,
+                        verbose = verbose)
 
   selected_columns <- colnames(data) %in% select
   colnames(data)[selected_columns] <- paste0(pattern, colnames(data)[selected_columns])

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -13,6 +13,8 @@ data_addprefix(
   select = NULL,
   exclude = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
+  verbose = TRUE,
   ...
 )
 
@@ -74,6 +76,17 @@ excludes no columns.}
 \item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
 a regular expression is used in \code{select}, ignores lower/upper case in the
 search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains("")} or \code{select = regex("")}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
+
+\item{verbose}{Toggle warnings.}
 
 \item{...}{Other arguments passed to or from other functions.}
 

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -24,6 +24,8 @@ data_addsuffix(
   select = NULL,
   exclude = NULL,
   ignore_case = FALSE,
+  regex = FALSE,
+  verbose = TRUE,
   ...
 )
 

--- a/tests/testthat/test-data_addprefix.R
+++ b/tests/testthat/test-data_addprefix.R
@@ -29,11 +29,12 @@ test_that("data_addprefix works as expected", {
 # select helpers ------------------------------
 test_that("data_addprefix regex", {
   expect_equal(
-    data_extract(mtcars, select = "pg", "regex", regex = TRUE),
-    data_extract(mtcars, select = "mpg", "regex")
+    data_addsuffix(mtcars, "_regex", select = "pg", regex = TRUE),
+    data_addsuffix(mtcars, "_regex", select = "mpg")
   )
   expect_equal(
-    data_extract(mtcars, select = "pg$", "regex", regex = TRUE),
-    data_extract(mtcars, select = "mpg", "regex")
+    data_addsuffix(mtcars, select = "pg$", "_regex", regex = TRUE),
+    data_addsuffix(mtcars, select = "mpg", "_regex")
   )
 })
+

--- a/tests/testthat/test-data_addprefix.R
+++ b/tests/testthat/test-data_addprefix.R
@@ -25,3 +25,15 @@ test_that("data_addprefix works as expected", {
     c("Sepal.Length", "Sepal.Width", "Petal.Length_OLD", "Petal.Width_OLD", "Species")
   )
 })
+
+# select helpers ------------------------------
+test_that("data_addprefix regex", {
+  expect_equal(
+    data_extract(mtcars, select = "pg", "regex", regex = TRUE),
+    data_extract(mtcars, select = "mpg", "regex")
+  )
+  expect_equal(
+    data_extract(mtcars, select = "pg$", "regex", regex = TRUE),
+    data_extract(mtcars, select = "mpg", "regex")
+  )
+})


### PR DESCRIPTION
Forgot this one last time so it's creating a bug in `performance::check_outliers`