### PR TITLE
data_to_wide: improve speed

### DIFF
--- a/R/data_reshape.R
+++ b/R/data_reshape.R
@@ -362,8 +362,9 @@ data_to_wide <- function(data,
 
   # Create an id for stats::reshape
   if (is.null(id_cols)) {
-    data[["_Rows"]] <-
-      apply(data[, !names(data) %in% c(values_from, names_from), drop = FALSE], 1, paste, collapse = "_")
+    row_index <- do.call(paste, c(data[, !names(data) %in% c(values_from, names_from), drop = FALSE], sep = "_"))
+    if (length(row_index) == 0) row_index <- rep("", nrow(data))
+    data[["_Rows"]] <- row_index
     id_cols <- "_Rows"
   }
 
@@ -373,7 +374,7 @@ data_to_wide <- function(data,
   current_colnames <- colnames(data)
   current_colnames <- current_colnames[current_colnames != "_Rows"]
   if (is.null(names_glue)) {
-    future_colnames <- unique(apply(data, 1, function(x) paste(x[c(names_from)], collapse = names_sep)))
+    future_colnames <- unique(do.call(paste, c(data[, names_from, drop = FALSE], sep = names_sep)))
   } else {
     vars <- regmatches(names_glue, gregexpr("\\{\\K[^{}]+(?=\\})", names_glue, perl = TRUE))[[1]]
     tmp_data <- unique(data[, vars])
@@ -404,7 +405,7 @@ data_to_wide <- function(data,
   # stats::reshape works strangely when several variables are in idvar/timevar
   # so we unite all ids in a single temporary column that will be used by
   # stats::reshape
-  data$new_time <- apply(data, 1, function(x) paste(x[names_from], collapse = "_"))
+  data$new_time <- do.call(paste, c(data[, names_from, drop = FALSE], sep = "_"))
   data[, names_from] <- NULL
 
   wide <- stats::reshape(


### PR DESCRIPTION
Prepare the benchmark:
``` r
library(tidyr)
library(datawizard)

# Make fake "big" data
df <- fish_encounters 
df$fish <- as.numeric(df$fish)

all_df <- list()

for (i in 1:200) {
  all_df[[i]] <- df 
  all_df[[i]]$fish <- all_df[[i]]$fish + 20*i
}

all <- tibble::as_tibble(data.table::rbindlist(all_df))
```

Current results:
```r
# Benchmark
bench::mark(
  datawizard = all %>% reshape_wider(names_from = "station", values_from = "seen")
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawizard    478ms    485ms      2.06      26MB     20.6
```
New results:
``` r
bench::mark(
  datawizard = all %>% reshape_wider(names_from = "station", values_from = "seen")
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawizard   95.9ms   96.9ms      10.3    20.1MB     20.6
```
For information, `tidyr::pivot_wider()` is still far ahead:
``` r
bench::mark(
  tidyr = all %>% pivot_wider(names_from = station, values_from = seen)
)
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tidyr        6.26ms   6.91ms      140.    3.48MB     17.5
```
