### PR TITLE
data_to_long: improve speed with names_pattern

### DIFF
--- a/R/data_reshape.R
+++ b/R/data_reshape.R
@@ -165,7 +165,7 @@ data_to_long <- function(data,
 
   # Cleaning --------------------------
   # Sort the dataframe (to match pivot_longer's output)
-  long <- data_arrange(long, c("_Row", names_to_2))
+  long <- long[do.call(order, long[, c("_Row", names_to_2)]), ]
 
   # Remove or rename the row index
   if (is.null(rows_to)) {


### PR DESCRIPTION
Improve speed when using `names_pattern`. 

Current results:
``` r
library(tidyr)
library(datawizard)

bench::mark(
  reshape_longer = who %>%
    reshape_longer(
      select = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_pattern = "new_?(.*)_(.)(.*)",
      values_to = "count"
    )
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 reshape_longer    3.56s    3.56s     0.281     768MB     4.21
```

New results:
``` r
library(tidyr)
library(datawizard)

bench::mark(
  reshape_longer = who %>%
    reshape_longer(
      select = 5:60,
      names_to = c("diagnosis", "gender", "age"),
      names_pattern = "new_?(.*)_(.)(.*)",
      values_to = "count"
    )
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 reshape_longer    1.69s    1.69s     0.592     367MB     7.11
```



