### PR TITLE
Add some tests for demean and data_merge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ BREAKING CHANGES
   
 * New `recode_values()` alias is introduced for `change_code()`, latter of which
   will be removed in the next release.
+  
+* `data_merge()` now errors if columns specified in `by` are not in both datasets.
 
 NEW FUNCTIONS
 

--- a/R/data_merge.R
+++ b/R/data_merge.R
@@ -220,16 +220,23 @@ data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, ver
     # If not all column names specified in "by" are present, yield warning
     # and use all shared column names
     if (!all(by %in% colnames(x)) || !all(by %in% colnames(y))) {
+      missing_in_x <- setdiff(by, colnames(x))
+      missing_in_y <- setdiff(by, colnames(y))
+      stop_message <- c("Not all columns specified in `by` were found in the data frames.",
+      if (length(missing_in_x) > 0) {
+        paste0("Following columns are in `by` but absent in `x`: ", text_concatenate(missing_in_x))
+      },
+      if (length(missing_in_y) > 0) {
+        paste0("Following columns are in `by` but absent in `y`: ", text_concatenate(missing_in_y))
+      })
       if (isTRUE(verbose)) {
-        warning(
+        stop(
           insight::format_message(
-            "Not all columns specified in `by` were found in the data frames.",
-            "Using all columns that are present in both data frames."
+            stop_message
           ),
           call. = FALSE
         )
       }
-      by <- intersect(colnames(x), colnames(y))
     }
 
     # if still both data frames have no common columns, do a full join

--- a/R/demean.R
+++ b/R/demean.R
@@ -281,13 +281,14 @@ degroup <- function(x,
   not_found <- setdiff(select, colnames(x))
 
   if (length(not_found) && isTRUE(verbose)) {
-    insight::print_color(
-      sprintf(
-        "%i variables were not found in the dataset: %s\n",
-        length(not_found),
-        paste0(not_found, collapse = ", ")
-      ),
-      color = "red"
+    message(
+      insight::format_message(
+        sprintf(
+          "%i variables were not found in the dataset: %s\n",
+          length(not_found),
+          paste0(not_found, collapse = ", ")
+        )
+      )
     )
   }
 

--- a/tests/testthat/test-data_merge.R
+++ b/tests/testthat/test-data_merge.R
@@ -147,6 +147,19 @@ test_that("bind-join", {
   # by will be ignored
   out <- data_merge(x, y, join = "bind", by = c("id", "mpg"))
   expect_equal(out, poor_out)
+
+  x <- mtcars[1, ]
+  y <- mtcars[2, ]
+  expect_warning(
+    out <- data_merge(x, y, join = "bind", id = "mpg"),
+    regexp = "already exists"
+  )
+  expect_equal(
+    names(out),
+    c(names(mtcars), "mpg_1")
+  )
+  expect_equal(out$mpg_1, c(1, 2))
+
 })
 
 # joins without common columns -----------------------
@@ -218,6 +231,18 @@ test_that("join data frames in a list", {
     subset(z, select = -id),
     ignore_attr = TRUE
   )
+
+  x <- mtcars[1, ]
+  y <- mtcars[2, ]
+  expect_warning(
+    out <- data_merge(list(x, y), join = "bind", id = "mpg"),
+    regexp = "already exists"
+  )
+  expect_equal(
+    names(out),
+    c(names(mtcars), "mpg_1")
+  )
+  expect_equal(out$mpg_1, c(1, 2))
 })
 
 
@@ -233,4 +258,20 @@ test_that("join empty data frames", {
   expect_equal(dim(data_merge(x, y, join = "right")), c(0, 1))
   expect_equal(dim(data_merge(x, y, join = "bind")), c(0, 1))
   expect_equal(dim(data_merge(x, z, join = "bind")), c(0, 2))
+})
+
+# join when all "by" are not present ---------------------
+
+test_that("join when all 'by' are not present", {
+  x <- mtcars[, c("mpg", "drat", "cyl", "qsec")]
+  y <- mtcars[, c("mpg", "hp", "cyl", "wt")]
+
+  expect_warning(
+    out <- data_merge(x, y, by = c("mpg", "drat")),
+    regexp = "Not all columns"
+  )
+  expect_equal(
+    out,
+    data_merge(x, y, by = c("mpg", "cyl"))
+  )
 })

--- a/tests/testthat/test-data_merge.R
+++ b/tests/testthat/test-data_merge.R
@@ -266,12 +266,8 @@ test_that("join when all 'by' are not present", {
   x <- mtcars[, c("mpg", "drat", "cyl", "qsec")]
   y <- mtcars[, c("mpg", "hp", "cyl", "wt")]
 
-  expect_warning(
-    out <- data_merge(x, y, by = c("mpg", "drat")),
+  expect_error(
+    out <- data_merge(x, y, by = c("mpg", "drat", "qsec")),
     regexp = "Not all columns"
-  )
-  expect_equal(
-    out,
-    data_merge(x, y, by = c("mpg", "cyl"))
   )
 })

--- a/tests/testthat/test-demean.R
+++ b/tests/testthat/test-demean.R
@@ -14,6 +14,13 @@ test_that("demean works", {
   set.seed(123)
   x <- demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID")
   expect_snapshot(head(x))
+
+  set.seed(123)
+  expect_equal(
+    demean(df, select = ~ Sepal.Length + binary + Species, group = ~ ID),
+    demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID")
+  )
+
 })
 
 test_that("demean interaction term", {
@@ -26,4 +33,19 @@ test_that("demean interaction term", {
 
   set.seed(123)
   expect_snapshot(demean(dat, select = c("a", "x*y"), group = "ID"))
+})
+
+test_that("demean shows message if some vars don't exist", {
+  dat <- data.frame(
+    a = c(1, 2, 3, 4, 1, 2, 3, 4),
+    x = c(4, 3, 3, 4, 1, 2, 1, 2),
+    y = c(1, 2, 1, 2, 4, 3, 2, 1),
+    ID = c(1, 2, 3, 1, 2, 3, 1, 2)
+  )
+
+  set.seed(123)
+  expect_message(
+    demean(dat, select = c("foo"), group = "ID"),
+    regexp = "not found"
+  )
 })


### PR DESCRIPTION
The default behavior of `data_merge()` when `by` columns are not present in both datasets is to warn the user and use all columns that are in both datasets to merge them (even if they are not specified in `by` originally).

This is really odd to me, I don't see when this behavior would be desired. I think an error would be more appropriate (which is the behavior in merge functions of dplyr btw). 