### PR TITLE
Fix tests for `data_peek`

### DIFF
--- a/tests/testthat/_snaps/data_peek.md
+++ b/tests/testthat/_snaps/data_peek.md
@@ -3,7 +3,7 @@
     Code
       data_peek(iris)
     Output
-      Data frame with 150 rows and 5 columns
+      Data frame with 150 rows and 5 variables
       
       Variable     | Type    | Values                                        
       -----------------------------------------------------------------------
@@ -16,9 +16,9 @@
 ---
 
     Code
-      data_peek(iris, n = 3)
+      data_peek(iris, select = 1:3)
     Output
-      Data frame with 150 rows and 5 columns
+      Data frame with 150 rows and 5 variables
       
       Variable     | Type    | Values                                        
       -----------------------------------------------------------------------
@@ -31,7 +31,7 @@
     Code
       data_peek(iris, width = 130)
     Output
-      Data frame with 150 rows and 5 columns
+      Data frame with 150 rows and 5 variables
       
       Variable     | Type    | Values                                                                                                  
       ---------------------------------------------------------------------------------------------------------------------------------

--- a/tests/testthat/test-data_peek.R
+++ b/tests/testthat/test-data_peek.R
@@ -8,12 +8,12 @@ test_that("data_peek works as expected", {
   expect_equal(dim(out), c(5, 3))
 })
 
-test_that("data_peek works as expected with custom n", {
-  out <- data_peek(iris, n = 3)
+test_that("data_peek works as expected with select", {
+  out <- data_peek(iris, select = 2:4)
   expect_equal(colnames(out), c("Variable", "Type", "Values"))
   expect_equal(
     out$Variable,
-    c("Sepal.Length", "Sepal.Width", "Petal.Length")
+    c("Sepal.Width", "Petal.Length", "Petal.Width")
   )
   expect_equal(dim(out), c(3, 3))
 })
@@ -30,6 +30,6 @@ test_that("data_peek works as expetced with custom width", {
 
 test_that("data_peek snapshots look as expected", {
   expect_snapshot(data_peek(iris))
-  expect_snapshot(data_peek(iris, n = 3))
+  expect_snapshot(data_peek(iris, select = 1:3))
   expect_snapshot(data_peek(iris, width = 130))
 })


### PR DESCRIPTION
Tests were broken by daa9c374fc9af4cdc4392f36adfc164bf20c2331