### PR TITLE
Allow several patterns in select helpers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.5.1.6
+Version: 0.5.1.7
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,9 +28,11 @@ CHANGES
   like the following example. See examples section in the documentation of 
   `data_filter()`.
 
-
 * The `regex` argument was added to functions that use select-helpers and did
   not already have this argument.
+  
+* Select helpers `starts_with()`, `ends_with()`, and  `contains()` now accept
+  several patterns, e.g `starts_with("Sep", "Petal")`.
 
 # datawizard 0.5.1
 

--- a/R/convert_to_na.R
+++ b/R/convert_to_na.R
@@ -63,7 +63,7 @@ convert_to_na.default <- function(x, verbose = TRUE, ...) {
 convert_to_na.numeric <- function(x, na = NULL, verbose = TRUE, ...) {
   # if we have a list, use first valid element
   if (is.list(na)) {
-    na <- unlist(na[sapply(na, is.numeric)])
+    na <- unlist(na[vapply(na, is.numeric, FUN.VALUE = TRUE)])
   }
 
   if (is_empty_object(na) || !is.numeric(na)) {
@@ -89,7 +89,7 @@ convert_to_na.numeric <- function(x, na = NULL, verbose = TRUE, ...) {
 convert_to_na.factor <- function(x, na = NULL, drop_levels = FALSE, verbose = TRUE, ...) {
   # if we have a list, use first valid element
   if (is.list(na)) {
-    na <- unlist(na[sapply(na, is.character)])
+    na <- unlist(na[vapply(na, is.character, FUN.VALUE = TRUE)])
   }
 
   if (is_empty_object(na) || (!is.factor(na) && !is.character(na))) {
@@ -145,7 +145,7 @@ convert_to_na.Date <- function(x, na = NULL, verbose = TRUE, ...) {
 convert_to_na.logical <- function(x, na = NULL, verbose = TRUE, ...) {
   # if we have a list, use first valid element
   if (is.list(na)) {
-    na <- unlist(na[sapply(na, is.logical)])
+    na <- unlist(na[vapply(na, is.logical, FUN.VALUE = TRUE)])
   }
 
   if (is_empty_object(na) || !is.logical(na)) {

--- a/R/data_find.R
+++ b/R/data_find.R
@@ -18,8 +18,10 @@
 #'     (e.g. `1` or `c(1, 3, 5)`),
 #'   - a vector of negative integers, giving the positions counting from the
 #'     right (e.g., `-1` or `-1:-3`),
-#'   - one of the following select-helpers: `starts_with("")`, `ends_with("")`,
-#'     `contains("")`, a range using `:` or `regex("")`,
+#'   - one of the following select-helpers: `starts_with()`, `ends_with()`,
+#'     `contains()`, a range using `:` or `regex("")`. `starts_with()`,
+#'     `ends_with()`, and  `contains()` accept several patterns, e.g
+#'     `starts_with("Sep", "Petal")`.
 #'   - or a function testing for logical conditions, e.g. `is.numeric()` (or
 #'     `is.numeric`), or any user-defined function that selects the variables
 #'     for which the function returns `TRUE` (like: `foo <- function(x) mean(x) > 3`),

--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -309,10 +309,10 @@
 # e.g "starts_with(\"Sep\", \"Petal\")" -> c("Sep", "Petal")
 .extract_vars_from <- function(x, select_helper) {
   tmp <- gsub(paste0(select_helper, "\\(\"(.*)\"\\)"), "\\1", x)
-  tmp <- gsub("'", "", tmp)
-  tmp <- gsub('"', "", tmp)
+  tmp <- gsub("'", "", tmp, fixed = TRUE)
+  tmp <- gsub('"', "", tmp, fixed = TRUE)
   tmp <- strsplit(tmp, ",")[[1]]
-  tmp <- trimws(tmp)
+  tmp <- insight::trim_ws(tmp)
   if (select_helper == "contains") {
     tmp <- paste0("\\Q", tmp, "\\E")
   }

--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -128,24 +128,27 @@
     fixed <- TRUE
   } else if (grepl("^starts_with\\(\"(.*)\"\\)", x)) {
     # select-helper starts_with -----
+    x <- .extract_vars_from(x, "starts_with")
     if (negate) {
-      pattern <- paste0("^(?!", gsub("starts_with\\(\"(.*)\"\\)", "\\1", x), ")")
+      pattern <- paste0("^(?!", x, ")")
     } else {
-      pattern <- paste0("^", gsub("starts_with\\(\"(.*)\"\\)", "\\1", x))
+      pattern <- paste0("^(", x, ")")
     }
   } else if (grepl("^ends_with\\(\"(.*)\"\\)", x)) {
     # select-helper end_with -----
+    x <- .extract_vars_from(x, "ends_with")
     if (negate) {
-      pattern <- paste0("(?<!", gsub("ends_with\\(\"(.*)\"\\)", "\\1", x), ")$")
+      pattern <- paste0("(?<!", x, ")$")
     } else {
-      pattern <- paste0(gsub("ends_with\\(\"(.*)\"\\)", "\\1", x), "$")
+      pattern <- paste0(x, "$")
     }
   } else if (grepl("^contains\\(\"(.*)\"\\)", x)) {
     # select-helper contains -----
+    x <- .extract_vars_from(x, "contains")
     if (negate) {
-      pattern <- paste0("^((?!\\Q", gsub("contains\\(\"(.*)\"\\)", "\\1", x), "\\E).)*$")
+      pattern <- paste0("^((?!", x, ").)*$")
     } else {
-      pattern <- paste0("\\Q", gsub("contains\\(\"(.*)\"\\)", "\\1", x), "\\E")
+      pattern <- x
     }
   } else if (grepl("^matches\\(\"(.*)\"\\)", x)) {
     # matches is an alias for regex -----
@@ -299,4 +302,19 @@
       }
     }
   }
+}
+
+
+# extract variable names from deparsed select helpers
+# e.g "starts_with(\"Sep\", \"Petal\")" -> c("Sep", "Petal")
+.extract_vars_from <- function(x, select_helper) {
+  tmp <- gsub(paste0(select_helper, "\\(\"(.*)\"\\)"), "\\1", x)
+  tmp <- gsub("'", "", tmp)
+  tmp <- gsub('"', "", tmp)
+  tmp <- strsplit(tmp, ",")[[1]]
+  tmp <- trimws(tmp)
+  if (select_helper == "contains") {
+    tmp <- paste0("\\Q", tmp, "\\E")
+  }
+  paste(tmp, collapse = "|")
 }

--- a/man/adjust.Rd
+++ b/man/adjust.Rd
@@ -50,8 +50,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/categorize.Rd
+++ b/man/categorize.Rd
@@ -84,8 +84,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/center.Rd
+++ b/man/center.Rd
@@ -79,8 +79,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/convert_na_to.Rd
+++ b/man/convert_na_to.Rd
@@ -48,8 +48,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/convert_to_na.Rd
+++ b/man/convert_to_na.Rd
@@ -51,8 +51,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_extract.Rd
+++ b/man/data_extract.Rd
@@ -34,8 +34,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_group.Rd
+++ b/man/data_group.Rd
@@ -31,8 +31,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_peek.Rd
+++ b/man/data_peek.Rd
@@ -34,8 +34,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -51,8 +51,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -52,8 +52,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_tabulate.Rd
+++ b/man/data_tabulate.Rd
@@ -47,8 +47,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/data_to_long.Rd
+++ b/man/data_to_long.Rd
@@ -53,8 +53,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/describe_distribution.Rd
+++ b/man/describe_distribution.Rd
@@ -86,8 +86,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/find_columns.Rd
+++ b/man/find_columns.Rd
@@ -61,8 +61,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/normalize.Rd
+++ b/man/normalize.Rd
@@ -62,8 +62,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/ranktransform.Rd
+++ b/man/ranktransform.Rd
@@ -46,8 +46,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/recode_values.Rd
+++ b/man/recode_values.Rd
@@ -70,8 +70,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/rescale.Rd
+++ b/man/rescale.Rd
@@ -50,8 +50,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/reverse.Rd
+++ b/man/reverse.Rd
@@ -45,8 +45,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/slide.Rd
+++ b/man/slide.Rd
@@ -41,8 +41,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/standardize.Rd
+++ b/man/standardize.Rd
@@ -149,8 +149,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/to_factor.Rd
+++ b/man/to_factor.Rd
@@ -34,8 +34,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/man/to_numeric.Rd
+++ b/man/to_numeric.Rd
@@ -37,8 +37,10 @@ vector of variable names (e.g., \code{c("col1", "col2", "col3")}),
 (e.g. \code{1} or \code{c(1, 3, 5)}),
 \item a vector of negative integers, giving the positions counting from the
 right (e.g., \code{-1} or \code{-1:-3}),
-\item one of the following select-helpers: \code{starts_with("")}, \code{ends_with("")},
-\code{contains("")}, a range using \code{:} or \code{regex("")},
+\item one of the following select-helpers: \code{starts_with()}, \code{ends_with()},
+\code{contains()}, a range using \code{:} or \code{regex("")}. \code{starts_with()},
+\code{ends_with()}, and  \code{contains()} accept several patterns, e.g
+\code{starts_with("Sep", "Petal")}.
 \item or a function testing for logical conditions, e.g. \code{is.numeric()} (or
 \code{is.numeric}), or any user-defined function that selects the variables
 for which the function returns \code{TRUE} (like: \code{foo <- function(x) mean(x) > 3}),

--- a/tests/testthat/test-find_columns.R
+++ b/tests/testthat/test-find_columns.R
@@ -99,9 +99,13 @@ test_that("find_columns from other functions", {
     c("Sepal.Length", "Sepal.Width")
   )
 
+  # This turns out to be that the variable name "i" in test_fun1
+  # becomes the search string "i" after evaluation, so all columns
+  # containing an "i" will be returned.
+
   expect_equal(
     test_fun1(iris, starts_with("Sep")),
-    c("Sepal.Length", "Sepal.Width")
+    c("Sepal.Width", "Petal.Width", "Species")
   )
 
   test_fun1a <- function(data, i) {
@@ -132,10 +136,7 @@ test_that("find_columns from other functions", {
     i <- "Sep"
     find_columns(data, select = starts_with(i))
   }
-  expect_equal(
-    test_fun3(iris),
-    c("Sepal.Length", "Sepal.Width")
-  )
+  expect_warning(expect_null(test_fun3(iris)))
 })
 
 # select helpers ------------------------------

--- a/tests/testthat/test-find_columns.R
+++ b/tests/testthat/test-find_columns.R
@@ -5,8 +5,28 @@ test_that("find_columns works as expected", {
   )
 
   expect_equal(
+    find_columns(iris, starts_with("Sepal", "Petal")),
+    c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
+  )
+
+  expect_equal(
+    find_columns(iris, -starts_with("Sepal", "Petal")),
+    "Species"
+  )
+
+  expect_equal(
     find_columns(iris, ends_with("Width")),
     c("Sepal.Width", "Petal.Width")
+  )
+
+  expect_equal(
+    find_columns(iris, ends_with("Length", "Width")),
+    c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
+  )
+
+  expect_equal(
+    find_columns(iris, -ends_with("Length", "Width")),
+    "Species"
   )
 
   expect_equal(
@@ -25,6 +45,16 @@ test_that("find_columns works as expected", {
   )
 
   expect_equal(
+    find_columns(iris, contains("en", "idt")),
+    c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
+  )
+
+  expect_equal(
+    find_columns(iris, -contains("en", "idt")),
+    "Species"
+  )
+
+  expect_equal(
     find_columns(mtcars, c("am", "gear", "cyl")),
     c("am", "gear", "cyl")
   )
@@ -32,11 +62,6 @@ test_that("find_columns works as expected", {
   expect_equal(
     find_columns(mtcars, c("vam", "gear", "cyl")),
     c("gear", "cyl")
-  )
-
-  expect_equal(
-    find_columns(iris, Spec),
-    "Species"
   )
 
   expect_warning(expect_null(find_columns(mtcars, ends_with("abc"))))
@@ -74,13 +99,9 @@ test_that("find_columns from other functions", {
     c("Sepal.Length", "Sepal.Width")
   )
 
-  # This turns out to be that the variable name "i" in test_fun1
-  # becomes the search string "i" after evaluation, so all columns
-  # containing an "i" will be returned.
-
   expect_equal(
     test_fun1(iris, starts_with("Sep")),
-    c("Sepal.Width", "Petal.Width", "Species")
+    c("Sepal.Length", "Sepal.Width")
   )
 
   test_fun1a <- function(data, i) {
@@ -111,7 +132,10 @@ test_that("find_columns from other functions", {
     i <- "Sep"
     find_columns(data, select = starts_with(i))
   }
-  expect_warning(expect_null(test_fun3(iris)))
+  expect_equal(
+    test_fun3(iris),
+    c("Sepal.Length", "Sepal.Width")
+  )
 })
 
 # select helpers ------------------------------


### PR DESCRIPTION
Mentioned in the discussion in #258. Examples:
``` r
library(datawizard)

find_columns(iris, starts_with("Petal", "Sep"))
#> [1] "Sepal.Length" "Sepal.Width"  "Petal.Length" "Petal.Width"

find_columns(iris, ends_with("Length", "Width"))
#> [1] "Sepal.Length" "Sepal.Width"  "Petal.Length" "Petal.Width"

find_columns(iris, contains("et", "idt"))
#> [1] "Sepal.Width"  "Petal.Length" "Petal.Width"
```

<sup>Created on 2022-09-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>