### PR TITLE
Selection: using "-" sign with numeric indices removes the columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.5.1.7
+Version: 0.5.1.8
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@ BREAKING CHANGES
   
 * `data_merge()` now errors if columns specified in `by` are not in both datasets.
 
+* Using negative values in arguments `select` and `exclude` now removes the columns
+  from the selection/exclusion. The previous behavior was to start the 
+  selection/exclusion from the end of the dataset, which was inconsistent with
+  the use of "-" with other selecting possibilities.
+
 NEW FUNCTIONS
 
 * `data_peek()`, to peek at values and type of variables in a data frame.

--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -319,11 +319,9 @@
   # if numeric, make sure we have valid column indices
   if (is.numeric(pattern)) {
     if (any(pattern < 0) && any(pattern > 0)) {
-      if (isTRUE(verbose)) {
-        stop(insight::format_message(
+      stop(insight::format_message(
           paste0("You can't mix negative and positive numeric indices in `select` or `exclude`.")
-        ), call. = FALSE)
-      }
+      ), call. = FALSE)
     }
     pattern <- columns[pattern]
   }

--- a/tests/testthat/test-data_relocate.R
+++ b/tests/testthat/test-data_relocate.R
@@ -47,7 +47,7 @@ test_that("data_relocate select-helpers", {
   )
   expect_equal(
     colnames(data_relocate(iris, select = -1)),
-    colnames(iris[c(5, 1:4)])
+    colnames(iris[c(2:5, 1)])
   )
   expect_equal(
     colnames(data_relocate(iris, select = Species, after = 1)),

--- a/tests/testthat/test-data_remove.R
+++ b/tests/testthat/test-data_remove.R
@@ -64,11 +64,11 @@ test_that("data_remove works with NSE", {
 
   expect_equal(
     colnames(data_remove(iris, -1:-2)),
-    colnames(iris)[1:3]
+    colnames(iris)[1:2]
   )
 
   expect_equal(
-    colnames(data_remove(iris, c(1, -1:-2))),
+    colnames(data_remove(iris, c(1, 4:5))),
     colnames(iris)[2:3]
   )
 

--- a/tests/testthat/test-find_columns.R
+++ b/tests/testthat/test-find_columns.R
@@ -10,11 +10,6 @@ test_that("find_columns works as expected", {
   )
 
   expect_equal(
-    find_columns(iris, -starts_with("Sepal", "Petal")),
-    "Species"
-  )
-
-  expect_equal(
     find_columns(iris, ends_with("Width")),
     c("Sepal.Width", "Petal.Width")
   )
@@ -22,11 +17,6 @@ test_that("find_columns works as expected", {
   expect_equal(
     find_columns(iris, ends_with("Length", "Width")),
     c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
-  )
-
-  expect_equal(
-    find_columns(iris, -ends_with("Length", "Width")),
-    "Species"
   )
 
   expect_equal(
@@ -47,11 +37,6 @@ test_that("find_columns works as expected", {
   expect_equal(
     find_columns(iris, contains("en", "idt")),
     c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
-  )
-
-  expect_equal(
-    find_columns(iris, -contains("en", "idt")),
-    "Species"
   )
 
   expect_equal(
@@ -138,10 +123,62 @@ test_that("find_columns from other functions", {
   )
 })
 
-# select helpers ------------------------------
 test_that("find_columns regex", {
   expect_equal(
     find_columns(mtcars, select = "pg", regex = TRUE),
     find_columns(mtcars, select = "mpg")
+  )
+})
+
+test_that("find_columns works correctly with minus sign", {
+
+  expect_equal(
+    find_columns(iris, -"Sepal.Length"),
+    c("Sepal.Width", "Petal.Length", "Petal.Width", "Species")
+  )
+
+  expect_equal(
+    find_columns(iris, -c("Sepal.Length", "Petal.Width")),
+    c("Sepal.Width", "Petal.Length", "Species")
+  )
+
+  expect_equal(
+    find_columns(iris, -1),
+    c("Sepal.Width", "Petal.Length", "Petal.Width", "Species")
+  )
+
+  expect_error(
+    find_columns(iris, -1:2),
+    regexp = "may be mixed"
+  )
+
+  expect_equal(
+    find_columns(iris, -(1:2)),
+    c("Petal.Length", "Petal.Width", "Species")
+  )
+
+  expect_equal(
+    find_columns(iris, -c(1, 3)),
+    c("Sepal.Width", "Petal.Width", "Species")
+  )
+
+  expect_equal(
+    find_columns(iris, -starts_with("Sepal", "Petal")),
+    "Species"
+  )
+
+  expect_equal(
+    find_columns(iris, -ends_with("Length", "Width")),
+    "Species"
+  )
+
+  expect_equal(
+    find_columns(iris, -contains("en", "idt")),
+    "Species"
+  )
+
+  expect_equal(
+    find_columns(iris, -c("Sepal.Length", "Petal.Width"), exclude = "Species"),
+    c("Sepal.Width", "Petal.Length")
   )
 })

--- a/tests/testthat/test-find_columns.R
+++ b/tests/testthat/test-find_columns.R
@@ -149,7 +149,7 @@ test_that("find_columns works correctly with minus sign", {
 
   expect_error(
     find_columns(iris, -1:2),
-    regexp = "may be mixed"
+    regexp = "can't mix negative"
   )
 
   expect_equal(

--- a/tests/testthat/test-get_columns.R
+++ b/tests/testthat/test-get_columns.R
@@ -161,17 +161,17 @@ test_that("get_columns works with ranges", {
 test_that("get_columns works with negated ranges", {
   expect_equal(
     get_columns(iris, -(1:2)),
-    iris[c(4, 5)]
+    iris[c(3, 4, 5)]
   )
 
   expect_equal(
     get_columns(iris, -1:-2),
-    iris[c(4, 5)]
+    iris[c(3, 4, 5)]
   )
 
   expect_equal(
     get_columns(iris, exclude = -1:-2),
-    iris[1:3]
+    iris[1:2]
   )
 
   expect_equal(

--- a/tests/testthat/test-select_nse.R
+++ b/tests/testthat/test-select_nse.R
@@ -3,16 +3,16 @@ foo <- function(data, select = NULL, exclude = NULL, regex = FALSE) {
 }
 
 test_that(".select_nse needs data", {
-  expect_error(.select_nse(select = "Sepal.Length", data = NULL), regexp = "must be provided")
+  expect_error(foo(select = "Sepal.Length", data = NULL), regexp = "must be provided")
 })
 
 test_that(".select_nse needs a data frame or something coercible to a dataframe", {
   expect_equal(
-    .select_nse(select = "Sepal.Length", data = as.matrix(head(iris))),
+    foo(select = "Sepal.Length", data = as.matrix(head(iris))),
     "Sepal.Length"
   )
   expect_error(
-    .select_nse(select = "Sepal.Length", data = list(1:3, 1:2)),
+    foo(select = "Sepal.Length", data = list(1:3, 1:2)),
     regexp = "must be a data frame"
   )
 })
@@ -98,3 +98,4 @@ test_that(".select_nse: args 'select' and 'exclude' at the same time", {
     character(0)
   )
 })
+


### PR DESCRIPTION
Close #258. This PR changes the behavior of select and exclude when there's a minus sign in front of numeric values.

Previously: select the columns starting from the right of the dataset (inconsistent with the behavior of the "-" with other selections).

Now: remove the columns.

``` r
library(datawizard)

find_columns(iris, -c("Sepal.Length", "Petal.Width"))
#> [1] "Sepal.Width"  "Petal.Length" "Species"

find_columns(iris, -1)
#> [1] "Sepal.Width"  "Petal.Length" "Petal.Width"  "Species"

# doesn't work
find_columns(iris, -1:2)
#> Error: You can't mix negative and positive numeric indices in `select` or
#>   `exclude`.

# works
find_columns(iris, -(1:2))
#> [1] "Petal.Length" "Petal.Width"  "Species"

find_columns(iris, -c(1, 3))
#> [1] "Sepal.Width" "Petal.Width" "Species"

find_columns(iris, -starts_with("Sepal", "Petal"))
#> [1] "Species"

find_columns(iris, -ends_with("Length", "Width"))
#> [1] "Species"
```

<sup>Created on 2022-09-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


--- 

Note: it would be better to detect the minus sign at the beginning of `.select_nse()`, make a boolean "invert_selection" and inverse the selection at the complete end of the function. With that, we could remove all the `if (negate)` conditions in the code. 

Problem: it's hard to get the expression of "select", remove the minus sign, and re-assign it to "select" for every type of input. In particular, it's hard to do that with functions with parenthesis (e.g `select = is.numeric()`) because using `substitute` and then `str2lang()` does not convert them back to functions.