### PR TITLE
Use `insight::format_*` messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ BugReports: https://github.com/easystats/datawizard/issues
 Depends:
     R (>= 3.6)
 Imports:
-    insight (>= 0.18.2),
+    insight (>= 0.18.3),
     stats,
     utils
 Suggests: 

--- a/R/adjust.R
+++ b/R/adjust.R
@@ -76,10 +76,10 @@ adjust <- function(data,
                    regex = FALSE,
                    verbose = FALSE) {
   if (!all(colnames(data) == make.names(colnames(data), unique = TRUE))) {
-    warning(insight::format_message(
+    insight::format_warning(
       "Bad column names (e.g., with spaces) have been detected which might create issues in many functions.",
       "Please fix it (you can run `names(mydata) <- make.names(names(mydata))` for a quick fix)."
-    ), call. = FALSE)
+    )
   }
 
   # check for formula notation, convert to character vector

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -121,9 +121,9 @@ categorize <- function(x, ...) {
 #' @export
 categorize.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0("Variables of class `", class(x)[1], "` can't be recoded and remain unchanged.")
-    ))
+    )
   }
   return(x)
 }
@@ -151,15 +151,15 @@ categorize.numeric <- function(x,
   }
 
   if (is.character(split) && split %in% c("quantile", "equal_length") && is.null(n_groups)) {
-    stop(insight::format_message(
+    insight::format_error(
       "Recoding based on quantiles or equal-sized groups requires the `n_groups` argument to be specified."
-    ), call. = FALSE)
+    )
   }
 
   if (is.character(split) && split == "equal_range" && is.null(n_groups) && is.null(range)) {
-    stop(insight::format_message(
+    insight::format_error(
       "Recoding into groups with equal range requires either the `range` or `n_groups` argument to be specified."
-    ), call. = FALSE)
+    )
   }
 
 
@@ -182,9 +182,9 @@ categorize.numeric <- function(x,
   # stop if all NA
   if (!length(x)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         "Variable contains only missing values. No recoding carried out."
-      ), call. = FALSE)
+      )
     }
     return(original_x)
   }
@@ -227,10 +227,10 @@ categorize.numeric <- function(x,
       original_x <- as.factor(original_x)
       levels(original_x) <- labels
     } else if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         "Argument `labels` and levels of the recoded variable are not of the same length.",
         "Variable will not be converted to factor."
-      ), call. = FALSE)
+      )
     }
   }
 

--- a/R/center.R
+++ b/R/center.R
@@ -92,10 +92,10 @@ centre <- center
 #' @export
 center.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       sprintf("Centering currently not possible for variables of class `%s`.", class(x)[1]),
       "You may open an issue at https://github.com/easystats/datawizard/issues."
-    ))
+    )
   }
   x
 }

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -78,9 +78,9 @@ convert_na_to <- function(x, ...) {
 #' @export
 convert_na_to.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       sprintf("Converting missing values (`NA`) into regular values currently not possible for variables of class `%s`.", class(x)[1])
-    ))
+    )
   }
   x
 }
@@ -91,11 +91,11 @@ convert_na_to.default <- function(x, verbose = TRUE, ...) {
 convert_na_to.numeric <- function(x, replacement = NULL, verbose = TRUE, ...) {
   if (is_empty_object(replacement) || !is.numeric(replacement)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`replacement` needs to be a numeric vector."), call. = FALSE)
+      insight::format_warning("`replacement` needs to be a numeric vector.")
     }
   } else if (length(replacement) > 1) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`replacement` needs to be of length one."), call. = FALSE)
+      insight::format_warning("`replacement` needs to be of length one.")
     }
   } else {
     x[is.na(x)] <- replacement
@@ -108,7 +108,7 @@ convert_na_to.numeric <- function(x, replacement = NULL, verbose = TRUE, ...) {
 convert_na_to.factor <- function(x, replacement = NULL, verbose = TRUE, ...) {
   if (is_empty_object(replacement) || length(replacement) > 1) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`replacement` needs to be of length one."), call. = FALSE)
+      insight::format_warning("`replacement` needs to be of length one.")
     }
   } else {
     x <- addNA(x)
@@ -124,13 +124,13 @@ convert_na_to.factor <- function(x, replacement = NULL, verbose = TRUE, ...) {
 convert_na_to.character <- function(x, replacement = NULL, verbose = TRUE, ...) {
   if (is_empty_object(replacement) || !is.character(replacement) && !is.numeric(replacement)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         "`replacement` needs to be a character or numeric vector."
-      ), call. = FALSE)
+      )
     }
   } else if (length(replacement) > 1) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`replacement` needs to be of length one."), call. = FALSE)
+      insight::format_warning("`replacement` needs to be of length one.")
     }
   } else {
     x[is.na(x)] <- as.character(replacement)

--- a/R/convert_to_na.R
+++ b/R/convert_to_na.R
@@ -47,12 +47,12 @@ convert_to_na <- function(x, ...) {
 #' @export
 convert_to_na.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       sprintf(
         "Converting values into missing values (`NA`) currently not possible for variables of class `%s`.",
         class(x)[1]
       )
-    ))
+    )
   }
   x
 }
@@ -68,10 +68,10 @@ convert_to_na.numeric <- function(x, na = NULL, verbose = TRUE, ...) {
 
   if (is_empty_object(na) || !is.numeric(na)) {
     if (isTRUE(verbose)) {
-      message(insight::format_message(
+      insight::format_alert(
         "Could not convert values into `NA` for a numeric variable.",
         "To do this, `na` needs to be a numeric vector, or a list that contains numeric vector elements."
-      ))
+      )
     }
   } else {
     matches <- which(x %in% na)
@@ -94,10 +94,10 @@ convert_to_na.factor <- function(x, na = NULL, drop_levels = FALSE, verbose = TR
 
   if (is_empty_object(na) || (!is.factor(na) && !is.character(na))) {
     if (isTRUE(verbose)) {
-      message(insight::format_message(
+      insight::format_alert(
         "Could not convert values into `NA` for a factor or character variable.",
         "To do this, `na` needs to be a character vector, or a list that contains character vector elements."
-      ))
+      )
     }
   } else {
     matches <- which(x %in% na)
@@ -128,10 +128,10 @@ convert_to_na.Date <- function(x, na = NULL, verbose = TRUE, ...) {
 
   if (is_empty_object(na) || !is.character(na)) {
     if (isTRUE(verbose)) {
-      message(insight::format_message(
+      insight::format_alert(
         "Could not convert values into `NA` for a date/time variable.",
         "To do this, `na` needs to be a character vector, or a list that contains character vector elements."
-      ))
+      )
     }
   } else {
     matches <- which(x %in% as.Date(na))
@@ -150,10 +150,10 @@ convert_to_na.logical <- function(x, na = NULL, verbose = TRUE, ...) {
 
   if (is_empty_object(na) || !is.logical(na)) {
     if (isTRUE(verbose)) {
-      message(insight::format_message(
+      insight::format_alert(
         "Could not convert values into `NA` for a logical variable.",
         "To do this, `na` needs to be a logical vector, or a list that contains logical vector elements."
-      ))
+      )
     }
   } else {
     matches <- which(x == na)

--- a/R/data_arrange.R
+++ b/R/data_arrange.R
@@ -46,12 +46,12 @@ data_arrange <- function(data, select = NULL, safe = TRUE) {
   dont_exist <- select[which(!select %in% names(data))]
   if (length(dont_exist) > 0) {
     if (!safe) {
-      stop(insight::format_message(
+      insight::format_error(
         paste0(
           "The following column(s) don't exist in the dataset: ",
           text_concatenate(dont_exist), "."
         )
-      ), call. = FALSE)
+      )
     }
     select <- select[-which(select %in% dont_exist)]
   }

--- a/R/data_find.R
+++ b/R/data_find.R
@@ -145,9 +145,9 @@ find_columns <- function(data,
   if (!length(columns) || is.null(columns)) {
     columns <- NULL
     if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         "No column names that matched the required search pattern were found."
-      ), call. = FALSE)
+      )
     }
   }
 

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -116,9 +116,9 @@ data_match <- function(x, to, match = "and", return_indices = FALSE, drop_na = T
   # sanity check
   shared_columns <- intersect(colnames(x), colnames(to))
   if (is.null(shared_columns) || length(shared_columns) == 0) {
-    stop(insight::format_message(
+    insight::format_error(
       "None of the columns from the data frame with matching conditions were found in `x`."
-    ), call. = FALSE)
+    )
   }
 
   # only select common columns
@@ -208,9 +208,9 @@ data_filter <- function(x, filter, ...) {
       error = function(e) NULL
     )
     if (is.null(out)) {
-      stop(insight::format_message(
+      insight::format_error(
         "Filtering did not work. Please check the syntax of your `filter` argument."
-      ), call. = FALSE)
+      )
     }
   }
   # restore value and variable labels
@@ -239,9 +239,9 @@ data_filter <- function(x, filter, ...) {
   # about possible misspelled comparisons / logical conditions
   # check if "=" instead of "==" was used?
   if (any(grepl("=", tmp, fixed = TRUE))) {
-    stop(insight::format_message(
+    insight::format_error(
       "Filtering did not work. Please check if you need `==` (instead of `=`) for comparison."
-    ), call. = FALSE)
+    )
   }
   # check if "&&" etc instead of "&" was used?
   logical_operator <- NULL
@@ -252,13 +252,13 @@ data_filter <- function(x, filter, ...) {
     logical_operator <- "||"
   }
   if (!is.null(logical_operator)) {
-    stop(insight::format_message(
+    insight::format_error(
       paste0(
         "Filtering did not work. Please check if you need `",
         substr(logical_operator, 0, 1),
         "` (instead of `", logical_operator, "`) as logical operator."
       )
-    ), call. = FALSE)
+    )
   }
 }
 # styler: on

--- a/R/data_merge.R
+++ b/R/data_merge.R
@@ -197,9 +197,9 @@ data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, ver
     id <- make.unique(c(all_columns, id), sep = "_")[length(all_columns) + 1]
     # and also tell user...
     if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         sprintf("Value of `id` already exists as column name. ID column was renamed to `%s`.", id)
-      ), call. = FALSE)
+      )
     }
   }
 
@@ -232,25 +232,17 @@ data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, ver
         }
       )
       if (isTRUE(verbose)) {
-        stop(
-          insight::format_message(
-            stop_message
-          ),
-          call. = FALSE
-        )
+        insight::format_error(stop_message)
       }
     }
 
     # if still both data frames have no common columns, do a full join
     if (!length(by)) {
       if (isTRUE(verbose)) {
-        warning(
-          insight::format_message(
-            "Found no matching columns in the data frames. Fully merging both data frames now.",
-            "Note that this can lead to unintended results, because rows in `x` and `y` are possibly duplicated.",
-            "You probably want to use `data_merge(x, y, join = \"bind\")` instead."
-          ),
-          call. = FALSE
+        insight::format_warning(
+          "Found no matching columns in the data frames. Fully merging both data frames now.",
+          "Note that this can lead to unintended results, because rows in `x` and `y` are possibly duplicated.",
+          "You probably want to use `data_merge(x, y, join = \"bind\")` instead."
         )
       }
       by <- NULL
@@ -262,12 +254,12 @@ data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, ver
   # check valid combination of "join" and "by" -----------------------
 
   if (join %in% c("anti", "semi") && (is.null(by) || length(by) != 1)) {
-    stop(insight::format_message(
+    insight::format_error(
       sprintf(
         "For `join = \"%s\"`, `by` needs to be a name of only one variable that is present in both data frames.",
         join
       )
-    ), call. = FALSE)
+    )
   }
 
 
@@ -356,9 +348,9 @@ data_merge.list <- function(x, join = "left", by = NULL, id = NULL, verbose = TR
       id <- make.unique(c(colnames(out), id), sep = "_")[length(colnames(out)) + 1]
       # and also tell user...
       if (isTRUE(verbose)) {
-        warning(insight::format_message(
+        insight::format_warning(
           sprintf("Value of `id` already exists as column name. ID column was renamed to `%s`.", id)
-        ), call. = FALSE)
+        )
       }
     }
     out[[id]] <- df_id

--- a/R/data_partition.R
+++ b/R/data_partition.R
@@ -56,9 +56,9 @@ data_partition <- function(data,
   if (!is.data.frame(data)) {
     data <- tryCatch(as.data.frame(data), error = function(e) NULL)
     if (is.null(data)) {
-      stop(insight::format_message(
+      insight::format_error(
         "`data` needs to be a data frame, or an object that can be coerced to a data frame."
-      ), call. = FALSE)
+      )
     }
   }
 
@@ -67,9 +67,9 @@ data_partition <- function(data,
   }
 
   if (sum(proportion) == 1 && isTRUE(verbose)) {
-    warning(insight::format_message(
+    insight::format_warning(
       "Proportions of sampled training sets (`proportion`) sums up to 1, so no test set will be generated."
-    ), call. = FALSE)
+    )
   }
 
   if (is.null(row_id)) {
@@ -80,12 +80,9 @@ data_partition <- function(data,
   # from overwriting. create new unique name for row-id then...
   if (row_id %in% colnames(data)) {
     if (isTRUE(verbose)) {
-      warning(
-        insight::format_message(
-          paste0("A variable named \"", row_id, "\" already exists."),
-          "Changing the value of `row_id` to a unique variable name now."
-        ),
-        call. = FALSE
+      insight::format_warning(
+        paste0("A variable named \"", row_id, "\" already exists."),
+        "Changing the value of `row_id` to a unique variable name now."
       )
     }
     unique_names <- make.unique(c(colnames(data), row_id), sep = "_")

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -77,19 +77,19 @@ data_rename <- function(data, pattern = NULL, replacement = NULL, safe = TRUE, .
   }
 
   if (length(replacement) > length(pattern)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0(
         "There are more names in `replacement` than in `pattern`. The last ",
         length(replacement) - length(pattern), " names of `replacement` are not used."
       )
-    ))
+    )
   } else if (length(replacement) < length(pattern)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0(
         "There are more names in `pattern` than in `replacement`. The last ",
         length(pattern) - length(replacement), " names of `pattern` are not modified."
       )
-    ))
+    )
   }
 
   for (i in seq_along(pattern)) {

--- a/R/data_rescale.R
+++ b/R/data_rescale.R
@@ -61,9 +61,9 @@ change_scale <- function(x, ...) {
 #' @export
 rescale.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0("Variables of class `", class(x)[1], "` can't be rescaled and remain unchanged.")
-    ))
+    )
   }
   x
 }
@@ -89,9 +89,9 @@ rescale.numeric <- function(x,
   # Warning if only one value
   if (length(unique(x)) == 1 && is.null(range)) {
     if (verbose) {
-      warning(insight::format_message(
+      insight::format_warning(
         "A `range` must be provided for data with only one unique value."
-      ), call. = FALSE)
+      )
     }
     return(x)
   }

--- a/R/data_reshape.R
+++ b/R/data_reshape.R
@@ -122,21 +122,21 @@ data_to_long <- function(data,
         verbose = FALSE
       )
     } else {
-      stop(insight::format_message(
+      insight::format_error(
         "You need to specify columns to pivot, either with `select` or `cols`."
-      ), call. = FALSE)
+      )
     }
   }
 
 
   if (any(names_to %in% setdiff(names(data), cols))) {
-    stop(insight::format_message(
+    insight::format_error(
       "Some values of the columns specified in 'names_to' are already present as column names.",
       paste0(
         "Either use another value in `names_to` or rename the following columns: ",
         text_concatenate(names_to[which(names_to %in% setdiff(names(data), cols))])
       )
-    ), call. = FALSE)
+    )
   }
 
   # Sanity checks ----------------
@@ -207,9 +207,9 @@ data_to_long <- function(data,
   # remove names prefix if specified
   if (!is.null(names_prefix)) {
     if (length(names_to) > 1) {
-      stop(insight::format_message(
+      insight::format_error(
         "`names_prefix` only works when `names_to` is of length 1."
-      ), call. = FALSE)
+      )
     }
     long[[names_to]] <- gsub(paste0("^", names_prefix), "", long[[names_to]])
   }
@@ -394,13 +394,13 @@ data_to_wide <- function(data,
 
   # stop if some column names would be duplicated (follow tidyr workflow)
   if (any(future_colnames %in% current_colnames)) {
-    stop(insight::format_message(
+    insight::format_error(
       "Some values of the columns specified in 'names_from' are already present as column names.",
       paste0(
         "Either use `name_prefix` or rename the following columns: ",
         text_concatenate(current_colnames[which(current_colnames %in% future_colnames)])
       )
-    ), call. = FALSE)
+    )
   }
 
   # stats::reshape works strangely when several variables are in idvar/timevar
@@ -449,26 +449,26 @@ data_to_wide <- function(data,
     if (length(values_fill) == 1) {
       if (is.numeric(wide[[new_cols[1]]])) {
         if (!is.numeric(values_fill)) {
-          stop(insight::format_message(paste0("`values_fill` must be of type numeric.")), call. = FALSE)
+          insight::format_error(paste0("`values_fill` must be of type numeric."))
         } else {
           wide <- convert_na_to(wide, replace_num = values_fill)
         }
       } else if (is.character(wide[[new_cols[1]]])) {
         if (!is.character(values_fill)) {
-          stop(insight::format_message(paste0("`values_fill` must be of type character.")), call. = FALSE)
+          insight::format_error(paste0("`values_fill` must be of type character."))
         } else {
           wide <- convert_na_to(wide, replace_char = values_fill)
         }
       } else if (is.factor(wide[[new_cols[1]]])) {
         if (!is.factor(values_fill)) {
-          stop(insight::format_message(paste0("`values_fill` must be of type factor.")), call. = FALSE)
+          insight::format_error(paste0("`values_fill` must be of type factor."))
         } else {
           wide <- convert_na_to(wide, replace_fac = values_fill)
         }
       }
     } else {
       if (verbose) {
-        stop(insight::format_message("`values_fill` must be of length 1."), call. = FALSE)
+        insight::format_error("`values_fill` must be of length 1.")
       }
     }
   }

--- a/R/data_reverse.R
+++ b/R/data_reverse.R
@@ -45,13 +45,13 @@ reverse_scale <- reverse
 #' @export
 reverse.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0(
         "Variables of class '",
         class(x)[1],
         "' can't be recoded and remain unchanged."
       )
-    ))
+    )
   }
 
   x

--- a/R/data_rotate.R
+++ b/R/data_rotate.R
@@ -60,7 +60,7 @@ data_rotate <- function(data, rownames = NULL, colnames = FALSE, verbose = TRUE)
   # warning after possible removal of columns
   if (length(unique(sapply(data, class))) > 1) {
     if (verbose) {
-      warning(insight::format_message("Your data frame contains mixed types of data. After transposition, all variables will be transformed into characters."), call. = FALSE)
+      insight::format_warning("Your data frame contains mixed types of data. After transposition, all variables will be transformed into characters.")
     }
   }
 

--- a/R/data_select.R
+++ b/R/data_select.R
@@ -21,7 +21,7 @@ get_columns <- function(data,
 
   if (!length(columns) || is.null(columns)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("No column names that matched the required search pattern were found."), call. = FALSE)
+      insight::format_warning("No column names that matched the required search pattern were found.")
     }
     return(NULL)
   }

--- a/R/demean.R
+++ b/R/demean.R
@@ -281,13 +281,11 @@ degroup <- function(x,
   not_found <- setdiff(select, colnames(x))
 
   if (length(not_found) && isTRUE(verbose)) {
-    message(
-      insight::format_message(
-        sprintf(
-          "%i variables were not found in the dataset: %s\n",
-          length(not_found),
-          paste0(not_found, collapse = ", ")
-        )
+    insight::format_alert(
+      sprintf(
+        "%i variables were not found in the dataset: %s\n",
+        length(not_found),
+        paste0(not_found, collapse = ", ")
       )
     )
   }

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -58,9 +58,8 @@ describe_distribution <- function(x, ...) {
 #' @export
 describe_distribution.default <- function(x, verbose = TRUE, ...) {
   if (verbose) {
-    warning(
-      insight::format_message(paste0("Can't describe variables of class `", class(x)[1], "`.")),
-      call. = FALSE
+    insight::format_warning(
+      paste0("Can't describe variables of class `", class(x)[1], "`.")
     )
   }
   NULL

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -53,9 +53,9 @@ distribution_coef_var <- coef_var
 #' @export
 coef_var.default <- function(x, verbose = TRUE, ...) {
   if (verbose) {
-    warning(insight::format_message(
+    insight::format_warning(
       paste0("Can't compute the coefficient of variation objects of class `", class(x)[1], "`.")
-    ), call. = FALSE)
+    )
   }
   NULL
 }
@@ -142,9 +142,9 @@ coef_var.numeric <- function(x, mu = NULL, sigma = NULL,
   out <- sigma / mu
   if (method == "unbiased") {
     if (is.null(n)) {
-      stop(insight::format_message(
+      insight::format_error(
         "A value for `n` must be provided when `method = \"unbiased\"` and both `mu` and `sigma` are provided."
-      ), call. = FALSE)
+      )
     }
     # from DescTools::CoefVar
     out <- out * (1 - 1 / (4 * (n - 1)) + 1 / n * out^2 + 1 / (2 * (n - 1)^2))

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -73,13 +73,13 @@ normalize.numeric <- function(x, include_bounds = TRUE, verbose = TRUE, ...) {
   # Warning if only one value
   if (insight::n_unique(x) == 1) {
     if (verbose) {
-      warning(insight::format_message(
+      insight::format_warning(
         paste0(
           "Variable `",
           name,
           "` contains only one unique value and will not be normalized."
         )
-      ), call. = FALSE)
+      )
     }
     return(x)
   }
@@ -88,13 +88,13 @@ normalize.numeric <- function(x, include_bounds = TRUE, verbose = TRUE, ...) {
   # Warning if logical vector
   if (insight::n_unique(x) == 2) {
     if (verbose) {
-      warning(insight::format_message(
+      insight::format_warning(
         paste0(
           "Variable `",
           name,
           "` contains only two different values. Consider converting it to a factor."
         )
-      ), call. = FALSE)
+      )
     }
   }
 

--- a/R/recode_values.R
+++ b/R/recode_values.R
@@ -183,9 +183,9 @@ recode_values <- function(x, ...) {
 #' @export
 recode_values.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       paste0("Variables of class `", class(x)[1], "` can't be recoded and remain unchanged.")
-    ))
+    )
   }
   return(x)
 }
@@ -497,7 +497,7 @@ recode_values.data.frame <- function(x,
   # skip if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     ok <- FALSE
   }
@@ -505,7 +505,7 @@ recode_values.data.frame <- function(x,
   # warn if not a list
   if (!is.list(recode) || is.null(names(recode))) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("`recode` needs to be a (named) list. No recoding carried out."), call. = FALSE)
+      insight::format_warning("`recode` needs to be a (named) list. No recoding carried out.")
     }
     ok <- FALSE
   }

--- a/R/rescale_weights.R
+++ b/R/rescale_weights.R
@@ -108,14 +108,11 @@ rescale_weights <- function(data, group, probability_weights, nest = FALSE) {
   data_tmp$.bamboozled <- 1:nrow(data_tmp)
 
   if (nest && length(group) < 2) {
-    warning(
-      insight::format_message(
-        sprintf(
-          "Only one group variable selected, no nested structure possible. Rescaling weights for grout '%s' now.",
-          group
-        )
-      ),
-      call. = FALSE
+    insight::format_warning(
+      sprintf(
+        "Only one group variable selected, no nested structure possible. Rescaling weights for grout '%s' now.",
+        group
+      )
     )
     nest <- FALSE
   }

--- a/R/select_helpers.R
+++ b/R/select_helpers.R
@@ -316,9 +316,9 @@
   # if numeric, make sure we have valid column indices
   if (is.numeric(pattern)) {
     if (any(pattern < 0) && any(pattern > 0)) {
-      stop(insight::format_message(
+      insight::format_error(
         paste0("You can't mix negative and positive numeric indices in `select` or `exclude`.")
-      ), call. = FALSE)
+      )
     }
     pattern <- columns[pattern]
   }
@@ -336,9 +336,9 @@
   # check if colnames are in data
   if (!all(pattern %in% columns)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message(
+      insight::format_warning(
         paste0("Following variable(s) were not found: ", paste0(setdiff(pattern, columns), collapse = ", "))
-      ), call. = FALSE)
+      )
     }
     pattern <- intersect(pattern, columns)
   }
@@ -383,21 +383,13 @@
 
 .check_data <- function(data) {
   if (is.null(data)) {
-    stop(
-      insight::format_message("The `data` argument must be provided."),
-      call. = FALSE
-    )
+    insight::format_error("The `data` argument must be provided.")
   }
   # check data frame input
   if (!is.null(data) && !is.data.frame(data)) {
     data <- try(as.data.frame(data), silent = TRUE)
     if (inherits(data, c("try-error", "simpleError"))) {
-      stop(
-        insight::format_message(
-          "The `data` argument must be a data frame, or an object that can be coerced to a data frame."
-        ),
-        call. = FALSE
-      )
+      insight::format_error("The `data` argument must be a data frame, or an object that can be coerced to a data frame.")
     }
   }
 }

--- a/R/skewness_kurtosis.R
+++ b/R/skewness_kurtosis.R
@@ -123,11 +123,8 @@ skewness.numeric <- function(x,
 
   if (type == "2" && n < 3) {
     if (verbose) {
-      warning(
-        insight::format_message(
-          "Need at least 3 complete observations for type-2-skewness. Using 'type=\"1\"' now."
-        ),
-        call. = FALSE
+      insight::format_warning(
+        "Need at least 3 complete observations for type-2-skewness. Using 'type=\"1\"' now."
       )
     }
     type <- "1"
@@ -268,11 +265,8 @@ kurtosis.numeric <- function(x,
 
   if (type == "2" && n < 4) {
     if (verbose) {
-      warning(
-        insight::format_message(
-          "Need at least 4 complete observations for type-2-kurtosis Using 'type=\"1\"' now."
-        ),
-        call. = FALSE
+      insight::format_warning(
+        "Need at least 4 complete observations for type-2-kurtosis Using 'type=\"1\"' now."
       )
     }
     type <- "1"
@@ -432,11 +426,8 @@ summary.parameters_kurtosis <- function(object, test = FALSE, ...) {
   if (is.null(type) ||
     is.na(type) ||
     !(type %in% c("1", "2", "3", "I", "II", "III", "classic", "SPSS", "SAS", "Minitab"))) {
-    warning(
-      insight::format_message(
-        "'type' must be a character value from \"1\" to \"3\". Using 'type=\"2\"' now."
-      ),
-      call. = FALSE
+    insight::format_warning(
+      "'type' must be a character value from \"1\" to \"3\". Using 'type=\"2\"' now."
     )
     type <- "2"
   }

--- a/R/slide.R
+++ b/R/slide.R
@@ -34,10 +34,10 @@ slide <- function(x, ...) {
 #' @export
 slide.default <- function(x, lowest = 0, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       "Shifting non-numeric variables is not possible.",
       "Try using 'to_numeric()' and specify the 'lowest' argument."
-    ))
+    )
   }
   x
 }

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -131,7 +131,7 @@ standardise <- standardize
 
 # standardize.default <- function(x, verbose = TRUE, ...) {
 #   if (isTRUE(verbose)) {
-#     message(insight::format_message(sprintf("Standardizing currently not possible for variables of class '%s'.", class(x)[1])))
+#     insight::format_alert(sprintf("Standardizing currently not possible for variables of class '%s'.", class(x)[1])))
 #   }
 #   x
 # }

--- a/R/standardize.models.R
+++ b/R/standardize.models.R
@@ -68,13 +68,13 @@ standardize.default <- function(x,
                                 include_response = TRUE,
                                 ...) {
   if (!insight::is_model(x)) {
-    warning(insight::format_message(
+    insight::format_warning(
       paste0(
         "Objects or variables of class '",
         class(x)[1],
         "' cannot be standardized."
       )
-    ), call. = FALSE)
+    )
     return(x)
   }
 
@@ -106,12 +106,8 @@ standardize.default <- function(x,
   }
 
   if (m_info$is_bayesian) {
-    warning(
-      insight::format_message(
-        "Standardizing variables without adjusting priors may lead to bogus results unless priors are auto-scaled."
-      ),
-      call. = FALSE,
-      immediate. = TRUE
+    insight::format_warning(
+      "Standardizing variables without adjusting priors may lead to bogus results unless priors are auto-scaled."
     )
   }
 
@@ -179,13 +175,10 @@ standardize.default <- function(x,
   # can't std data$var variables
   if (any(doller_vars <- grepl("(.*)\\$(.*)", do_standardize))) {
     doller_vars <- colnames(data)[doller_vars]
-    warning(
-      insight::format_message(
-        "Unable to standardize variables evaluated in the environment (i.e., not in `data`).",
-        "The following variables will not be standardizd:",
-        paste0(doller_vars, collapse = ", ")
-      ),
-      call. = FALSE
+    insight::format_warning(
+      "Unable to standardize variables evaluated in the environment (i.e., not in `data`).",
+      "The following variables will not be standardizd:",
+      paste0(doller_vars, collapse = ", ")
     )
     do_standardize <- setdiff(do_standardize, doller_vars)
     dont_standardize <- c(dont_standardize, doller_vars)
@@ -244,11 +237,9 @@ standardize.default <- function(x,
   }
 
   if (verbose && length(c(log_terms, sqrt_terms))) {
-    message(
-      insight::format_message(
-        "Formula contains log- or sqrt-terms.",
-        "See help(\"standardize\") for how such terms are standardized."
-      )
+    insight::format_alert(
+      "Formula contains log- or sqrt-terms.",
+      "See help(\"standardize\") for how such terms are standardized."
     )
   }
 
@@ -294,12 +285,9 @@ standardize.brmsfit <- function(x,
                                 ...) {
   data_std <- NULL # needed to avoid note
   if (insight::is_multivariate(x)) {
-    stop(
-      insight::format_message(
-        "multivariate brmsfit models not supported.",
-        "As an alternative: you may standardize your data (and adjust your priors), and re-fit the model."
-      ),
-      call. = FALSE
+    insight::format_error(
+      "Multivariate brmsfit models not supported.",
+      "As an alternative: you may standardize your data (and adjust your priors), and re-fit the model."
     )
   }
 
@@ -380,10 +368,8 @@ standardize.mediate <- function(x,
       )
     )
     if (verbose) {
-      message(
-        insight::format_message(
-          "Covariates' values have been rescaled to their standardized scales."
-        )
+      insight::format_alert(
+        "Covariates' values have been rescaled to their standardized scales."
       )
     }
   }
@@ -404,12 +390,9 @@ standardize.mediate <- function(x,
   # }
 
   if (verbose && !all(c(control.value, treat.value) %in% c(0, 1))) {
-    warning(
-      insight::format_message(
-        "Control and treat values are not 0 and 1, and have not been re-scaled.",
-        "Interpret results with caution."
-      ),
-      call. = FALSE
+    insight::format_warning(
+      "Control and treat values are not 0 and 1, and have not been re-scaled.",
+      "Interpret results with caution."
     )
   }
 
@@ -478,12 +461,9 @@ standardize.biglm <- standardize.wbm
 .safe_to_standardize_response <- function(info, verbose = TRUE) {
   if (is.null(info)) {
     if (verbose) {
-      warning(
-        insight::format_message(
-          "Unable to verify if response should not be standardized.",
-          "Response will be standardized."
-        ),
-        immediate. = TRUE, call. = FALSE
+      insight::format_warning(
+        "Unable to verify if response should not be standardized.",
+        "Response will be standardized."
       )
     }
     return(TRUE)
@@ -537,11 +517,8 @@ standardize.biglm <- standardize.wbm
     msg1 <- sprintf("Standardization of parameters not possible for models of class '%s'.", class)
   }
 
-  stop(
-    insight::format_message(
-      msg1,
-      "Try instead to standardize the data (standardize(data)) and refit the model manually."
-    ),
-    call. = FALSE
+  insight::format_error(
+    msg1,
+    "Try instead to standardize the data (standardize(data)) and refit the model manually."
   )
 }

--- a/R/to_factor.R
+++ b/R/to_factor.R
@@ -31,9 +31,9 @@ to_factor <- function(x, ...) {
 #' @export
 to_factor.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(
+    insight::format_alert(
       sprintf("Converting into factors values currently not possible for variables of class `%s`.", class(x)[1])
-    ))
+    )
   }
   x
 }

--- a/R/to_numeric.R
+++ b/R/to_numeric.R
@@ -45,7 +45,12 @@ to_numeric <- function(x, ...) {
 #' @export
 to_numeric.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(sprintf("Converting into numeric values currently not possible for variables of class '%s'.", class(x)[1])))
+    insight::format_alert(
+      sprintf(
+        "Converting into numeric values currently not possible for variables of class '%s'.",
+        class(x)[1]
+      )
+    )
   }
   x
 }
@@ -153,10 +158,10 @@ to_numeric.logical <- to_numeric.numeric
 #' @export
 to_numeric.Date <- function(x, verbose = TRUE, ...) {
   if (verbose) {
-    warning(insight::format_message(
+    insight::format_warning(
       "Converting a date-time variable into numeric.",
       "Please note that this conversion probably not returns meaningful results."
-    ), call. = FALSE)
+    )
   }
   as.numeric(x)
 }

--- a/R/unnormalize.R
+++ b/R/unnormalize.R
@@ -22,7 +22,7 @@ unnormalize.numeric <- function(x, verbose = TRUE, ...) {
 
   if (is.null(min_value) || is.null(range_difference)) {
     if (verbose) {
-      warning(insight::format_message("Can't unnormalize variable. Information about range and/or minimum value is missing."), call. = FALSE)
+      insight::format_warning("Can't unnormalize variable. Information about range and/or minimum value is missing.")
     }
     return(x)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,9 +12,9 @@
 #' @param replacement Argument that replaces the deprecated argument
 #' @keywords internal
 .is_deprecated <- function(arg, replacement) {
-  warning(insight::format_message(
+  insight::format_warning(
     paste0("Argument `", arg, "` is deprecated. Please use `", replacement, "` instead.")
-  ), call. = FALSE)
+  )
 }
 
 #' `NULL` coalescing operator

--- a/R/utils_data.R
+++ b/R/utils_data.R
@@ -102,21 +102,17 @@ column_as_rownames <- function(x, var = "rowname") {
 #'
 row_to_colnames <- function(x, row = 1, na_prefix = "x", verbose = TRUE) {
   if (!is.numeric(row)) {
-    stop(
-      insight::format_message(paste0("Argument 'row' must be of type numeric."))
-    )
+    insight::format_error("Argument 'row' must be of type numeric.")
   }
   if (length(row) != 1) {
-    stop(
-      insight::format_message(paste0("Argument 'row' must be of length 1."))
-    )
+    insight::format_error("Argument 'row' must be of length 1.")
   }
   if (nrow(x) < row) {
-    stop(
-      insight::format_message(paste0(
+    insight::format_error(
+      paste0(
         "You used row = ", row,
         " but the dataset only has ", nrow(x), " rows."
-      ))
+      )
     )
   }
 
@@ -130,8 +126,12 @@ row_to_colnames <- function(x, row = 1, na_prefix = "x", verbose = TRUE) {
       new_colnames[which_na[i]] <- paste0(na_prefix, i)
     }
     if (verbose) {
-      warning(
-        insight::format_message(paste0("Some values of row ", row, " were NAs. The corresponding column names are prefixed with '", na_prefix, "'."))
+      insight::format_warning(
+        paste0(
+          "Some values of row ", row,
+          " were NAs. The corresponding column names are prefixed with '",
+          na_prefix, "'."
+        )
       )
     }
   }
@@ -146,14 +146,10 @@ row_to_colnames <- function(x, row = 1, na_prefix = "x", verbose = TRUE) {
 #' @export
 colnames_to_row <- function(x, prefix = "x") {
   if (length(prefix) != 1) {
-    stop(
-      insight::format_message(paste0("Argument 'prefix' must be of length 1."))
-    )
+    insight::format_error("Argument 'prefix' must be of length 1.")
   }
   if (!is.character(prefix)) {
-    stop(
-      insight::format_message(paste0("Argument 'prefix' must be of type character."))
-    )
+    insight::format_error("Argument 'prefix' must be of type character.")
   }
   x2 <- rbind(colnames(x), x)
   colnames(x2) <- paste0(prefix, 1:ncol(x2))

--- a/R/utils_standardize_center.R
+++ b/R/utils_standardize_center.R
@@ -79,9 +79,9 @@
     if (weights %in% colnames(x)) {
       exclude <- c(exclude, weights)
     } else {
-      warning(insight::format_message(
+      insight::format_warning(
         paste0("Could not find weighting column `", weights, "`. Weighting not carried out.")
-      ), call. = FALSE)
+      )
       weights <- NULL
     }
   }
@@ -141,9 +141,9 @@
 
     # center and scale must either be of length 1 or of same length as selected variables
     if (length(.center) > 1 && length(.center) != length(select)) {
-      stop(insight::format_message(
+      insight::format_error(
         "`center` and `scale` must have the same length as the selected variables for standardization or centering."
-      ), call. = FALSE)
+      )
     }
 
     # if of length 1, recycle
@@ -236,13 +236,13 @@
   if (length(unique(x)) == 1 && is.null(reference)) {
     if (verbose) {
       if (is.null(name)) {
-        message(insight::format_message(
+        insight::format_alert(
           "The variable contains only one unique value and will be set to 0."
-        ))
+        )
       } else {
-        message(insight::format_message(
+        insight::format_alert(
           paste0("The variable `", name, "` contains only one unique value and will be set to 0.")
-        ))
+        )
       }
     }
     return(NULL)
@@ -252,13 +252,13 @@
   if (length(unique(x)) == 2 && !is.factor(x) && !is.character(x)) {
     if (verbose) {
       if (is.null(name)) {
-        message(insight::format_message(
+        insight::format_alert(
           "The variable contains only two different values. Consider converting it to a factor."
-        ))
+        )
       } else {
-        message(insight::format_message(
+        insight::format_alert(
           paste0("Variable `", name, "` contains only two different values. Consider converting it to a factor.")
-        ))
+        )
       }
     }
   }
@@ -385,10 +385,10 @@
   grps <- attr(x, "groups", exact = TRUE)
 
   if (is.numeric(weights)) {
-    warning(insight::format_message(
+    insight::format_warning(
       "For grouped data frames, `weights` must be a character, not a numeric vector.",
       "Ignoring weightings."
-    ), call. = FALSE)
+    )
     weights <- NULL
   }
 

--- a/R/winsorize.R
+++ b/R/winsorize.R
@@ -99,12 +99,9 @@ winsorize.numeric <- function(data,
   if (method == "raw") {
     if (length(threshold) != 2L) {
       if (isTRUE(verbose)) {
-        warning(
-          insight::format_message(
-            "`threshold` must be of length 2 for lower and upper bound.",
-            "Did not winsorize data."
-          ),
-          call. = FALSE
+        insight::format_warning(
+          "`threshold` must be of length 2 for lower and upper bound.",
+          "Did not winsorize data."
         )
       }
       return(data)
@@ -114,12 +111,9 @@ winsorize.numeric <- function(data,
   if (method == "percentile") {
     if (threshold < 0 || threshold > 0.5) {
       if (isTRUE(verbose)) {
-        warning(
-          insight::format_message(
-            "`threshold` for winsorization must be a scalar between 0 and 0.5.",
-            "Did not winsorize data."
-          ),
-          call. = FALSE
+        insight::format_warning(
+          "`threshold` for winsorization must be a scalar between 0 and 0.5.",
+          "Did not winsorize data."
         )
       }
       return(data)
@@ -136,9 +130,8 @@ winsorize.numeric <- function(data,
   if (method == "zscore") {
     if (threshold <= 0) {
       if (isTRUE(verbose)) {
-        warning(
-          insight::format_message("'threshold' for winsorization must be a scalar greater than 0. Did not winsorize data."),
-          call. = FALSE
+        insight::format_warning(
+          "'threshold' for winsorization must be a scalar greater than 0. Did not winsorize data."
         )
       }
       return(data)

--- a/WIP/data_arrange2.R
+++ b/WIP/data_arrange2.R
@@ -46,7 +46,7 @@ data_arrange2 <- function(data,
   if (!is.null(descending) && length(descending) > 0) {
     # must be a vector of logicals
     if (!all(is.logical(descending))) {
-      stop(insight::format_message("`descending` must a a vector of logicals, either of length 1 or of same length as variables selected by `select`."), call. = FALSE)
+      insight::format_error("`descending` must a a vector of logicals, either of length 1 or of same length as variables selected by `select`.")
     }
     for (i in select[descending]) {
       out[[i]] <- -xtfrm(out[[i]])

--- a/WIP/data_recode_intuitive.R
+++ b/WIP/data_recode_intuitive.R
@@ -149,7 +149,7 @@ recode_values <- function(x, ...) {
 #' @export
 recode_values.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(paste0("Variables of class '", class(x)[1], "' can't be recoded and remain unchanged.")))
+    insight::format_alert(paste0("Variables of class '", class(x)[1], "' can't be recoded and remain unchanged."))
   }
   return(x)
 }
@@ -172,7 +172,7 @@ recode_values.numeric <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }
@@ -244,7 +244,7 @@ recode_values.factor <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }
@@ -312,7 +312,7 @@ recode_values.character <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }

--- a/WIP/data_recode_strange.R
+++ b/WIP/data_recode_strange.R
@@ -153,7 +153,7 @@ recode_values <- function(x, ...) {
 #' @export
 recode_values.default <- function(x, verbose = TRUE, ...) {
   if (isTRUE(verbose)) {
-    message(insight::format_message(paste0("Variables of class '", class(x)[1], "' can't be recoded and remain unchanged.")))
+    insight::format_alert(paste0("Variables of class '", class(x)[1], "' can't be recoded and remain unchanged."))
   }
   return(x)
 }
@@ -176,7 +176,7 @@ recode_values.numeric <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }
@@ -248,7 +248,7 @@ recode_values.factor <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }
@@ -317,7 +317,7 @@ recode_values.character <- function(x,
   # stop if all NA
   if (!length(valid)) {
     if (isTRUE(verbose)) {
-      warning(insight::format_message("Variable contains only missing values. No recoding carried out."), call. = FALSE)
+      insight::format_warning("Variable contains only missing values. No recoding carried out.")
     }
     return(original_x)
   }

--- a/WIP/data_transpose.R
+++ b/WIP/data_transpose.R
@@ -14,7 +14,7 @@
 data_transpose <- function(data, verbose = TRUE, ...) {
   if (length(unique(sapply(data, class))) > 1) {
     if (verbose) {
-      warning(insight::format_message("Your data contains mixed types of data. After transposition, all will be transformed into characters."), call. = FALSE)
+      insight::format_warning("Your data contains mixed types of data. After transposition, all will be transformed into characters.")
     }
   }
   new <- as.data.frame(t(data))


### PR DESCRIPTION
I only focused on cases where there were two functions used e.g:
 ```
stop(insight::format_message("error"), call. = FALSE) -> insight::format_error("error")
```
Should we also transition simple `stop()` messages, e.g should we do the following transition?
```
stop("error", call. = FALSE) -> insight::format_error("error")
```