### PR TITLE
remove dplyr < 0.8 code chunks

### DIFF
--- a/R/categorize.R
+++ b/R/categorize.R
@@ -317,8 +317,8 @@ categorize.grouped_df <- function(x,
                                   ...) {
   info <- attributes(x)
 
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   # evaluate arguments
   select <- .select_nse(select,
@@ -335,14 +335,6 @@ categorize.grouped_df <- function(x,
   # update processed arguments
   x <- args$x
   select <- args$select
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
-  }
 
   x <- as.data.frame(x)
   for (rows in grps) {

--- a/R/data_rescale.R
+++ b/R/data_rescale.R
@@ -125,8 +125,8 @@ rescale.grouped_df <- function(x,
                                ...) {
   info <- attributes(x)
 
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   # evaluate arguments
   select <- .select_nse(select,
@@ -136,14 +136,6 @@ rescale.grouped_df <- function(x,
     regex = regex,
     verbose = verbose
   )
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
-  }
 
   x <- as.data.frame(x)
   for (rows in grps) {

--- a/R/data_reverse.R
+++ b/R/data_reverse.R
@@ -143,8 +143,8 @@ reverse.grouped_df <- function(x,
                                ...) {
   info <- attributes(x)
 
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   # evaluate arguments
   select <- .select_nse(select,
@@ -154,14 +154,6 @@ reverse.grouped_df <- function(x,
     regex = regex,
     verbose = verbose
   )
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
-  }
 
   x <- as.data.frame(x)
   for (rows in grps) {

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -162,8 +162,8 @@ data_tabulate.grouped_df <- function(x,
                                      collapse = FALSE,
                                      drop_levels = FALSE,
                                      ...) {
-  # dplyr < 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
   group_variables <- NULL
 
   # evaluate arguments
@@ -174,15 +174,6 @@ data_tabulate.grouped_df <- function(x,
     regex = regex,
     verbose = verbose
   )
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    group_variables <- data_remove(grps, ".rows")
-    grps <- grps[[".rows"]]
-  }
 
   x <- as.data.frame(x)
   out <- list()

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -163,8 +163,9 @@ data_tabulate.grouped_df <- function(x,
                                      drop_levels = FALSE,
                                      ...) {
   # works only for dplyr >= 0.8.0
-  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
-  group_variables <- NULL
+  grps <- attr(x, "groups", exact = TRUE)
+  group_variables <- data_remove(grps, ".rows")
+  grps <- grps[[".rows"]]
 
   # evaluate arguments
   select <- .select_nse(select,

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -144,8 +144,8 @@ normalize.grouped_df <- function(x,
   )
 
   info <- attributes(x)
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   # check for formula notation, convert to character vector
   if (inherits(select, "formula")) {
@@ -153,14 +153,6 @@ normalize.grouped_df <- function(x,
   }
   if (inherits(exclude, "formula")) {
     exclude <- all.vars(exclude)
-  }
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
   }
 
   x <- as.data.frame(x)

--- a/R/ranktransform.R
+++ b/R/ranktransform.R
@@ -108,8 +108,8 @@ ranktransform.grouped_df <- function(x,
                                      verbose = TRUE,
                                      ...) {
   info <- attributes(x)
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   # evaluate arguments
   select <- .select_nse(select,
@@ -119,14 +119,6 @@ ranktransform.grouped_df <- function(x,
     regex = regex,
     verbose = verbose
   )
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
-  }
 
   x <- as.data.frame(x)
   for (rows in grps) {

--- a/R/unstandardize.R
+++ b/R/unstandardize.R
@@ -35,7 +35,7 @@ unstandardize.numeric <- function(x,
       scale <- attr(x, "scaled:scale", exact = TRUE)
       attr(x, "scaled:scale") <- attr(x, "scaled:center") <- NULL
     } else {
-      stop("You must provide the arguments `center`, `scale` or `reference`.")
+      insight::format_error("You must provide the arguments `center`, `scale` or `reference`.")
     }
   }
 
@@ -84,7 +84,7 @@ unstandardize.data.frame <- function(x,
       i <- names(x) %in% names(scale)
       i <- i[i]
     } else {
-      stop("You must provide the arguments `center`, `scale` or `reference`.")
+      insight::format_error("You must provide the arguments `center`, `scale` or `reference`.")
     }
   } else {
     if (is.null(names(center))) {
@@ -133,7 +133,7 @@ unstandardize.grouped_df <- function(x,
                                      robust = FALSE,
                                      two_sd = FALSE,
                                      ...) {
-  stop("Cannot (yet) unstandardize a grouped_df.")
+  insight::format_error("Cannot (yet) unstandardize a `grouped_df`.")
 }
 
 #' @export

--- a/R/utils_standardize_center.R
+++ b/R/utils_standardize_center.R
@@ -381,8 +381,8 @@
   }
 
   info <- attributes(x)
-  # dplyr >= 0.8.0 returns attribute "indices"
-  grps <- attr(x, "groups", exact = TRUE)
+  # works only for dplyr >= 0.8.0
+  grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
   if (is.numeric(weights)) {
     insight::format_warning(
@@ -390,15 +390,6 @@
       "Ignoring weightings."
     )
     weights <- NULL
-  }
-
-
-  # dplyr < 0.8.0?
-  if (is.null(grps)) {
-    grps <- attr(x, "indices", exact = TRUE)
-    grps <- lapply(grps, function(x) x + 1)
-  } else {
-    grps <- grps[[".rows"]]
   }
 
   x <- as.data.frame(x)


### PR DESCRIPTION
We have had compatibility for `grouped_df()` methods for dplyr < 0.8 - I think we can remove this and only rely on the structure of grouped df's used since dplyr 0.8 and higher.

no tests needed.