### PR TITLE
Improve performance of empty_rows()

### DIFF
--- a/R/remove_empty.R
+++ b/R/remove_empty.R
@@ -77,7 +77,7 @@ empty_rows <- function(x) {
   if ((!is.matrix(x) && !is.data.frame(x)) || nrow(x) < 2) {
     vector("numeric")
   } else {
-    which(rowSums(is.na(x) | apply(x, c(1, 2), function(i) nchar(as.character(i)) == 0)) == ncol(x))
+    which(apply(x, 1, function(i) all(is.na(i) | nchar(as.character(i)) == 0)))
   }
 }
 


### PR DESCRIPTION
Didn't have time to mention it in #275 before it was merged but we can improve the perf of `empty_rows()`:
``` r
# current
empty_rows <- function(x) {
  if ((!is.matrix(x) && !is.data.frame(x)) || nrow(x) < 2) {
    vector("numeric")
  } else {
    which(rowSums(is.na(x) | apply(x, c(1, 2), function(i) nchar(as.character(i)) == 0)) == ncol(x))
  }
}

# new
new_empty_rows <- function(x) {
  if ((!is.matrix(x) && !is.data.frame(x)) || nrow(x) < 2) {
    vector("numeric")
  } else {
    which(apply(x, 1, function(i) all(is.na(i) | nchar(as.character(i)) == 0)))
  }
}

tmp <- data.frame(
  a = c(1, 2, 3, NA, 5),
  b = c("", NA, "", NA, ""),
  c = c(NA, NA, NA, NA, NA),
  d = c(1, NA, 3, NA, 5),
  e = c("", "", "", "", ""),
  f = factor(c("", "", "", "", "")),
  g = factor(c("", NA, "", NA, "")),
  stringsAsFactors = FALSE
)

out <- list()
for (i in 1:100000) {
  out[[i]] <- tmp
}

out <- data.table::rbindlist(out)
nrow(out)
#> [1] 500000

bench::mark(
  old = empty_rows(out),
  new = new_empty_rows(out)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old           7.92s    7.92s     0.126     239MB     18.1
#> 2 new           2.79s    2.79s     0.359     122MB     14.0
```

<sup>Created on 2022-09-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
