### PR TITLE
`data_arrange`: return data early if already sorted

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.2.1
+Version: 0.6.2.2
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# datawizard 0.6.2.1
+# datawizard (development version)
 
 MAJOR CHANGES
 

--- a/R/data_arrange.R
+++ b/R/data_arrange.R
@@ -72,6 +72,12 @@ data_arrange.default <- function(data, select = NULL, safe = TRUE) {
     return(data)
   }
 
+  already_sorted <- all(unlist(lapply(data[, select, drop = FALSE], .is_sorted)))
+
+  if (already_sorted) {
+    return(data)
+  }
+
   out <- data
 
   # reverse order for variables that should be decreasing

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,3 +116,8 @@
   # no double white space
   insight::trim_ws(msg)
 }
+
+#' Check that a vector is sorted
+#' @noRd
+
+.is_sorted <- Negate(is.unsorted)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -34,3 +34,13 @@ test_that(".coerce_to_dataframe errors correctly if can't coerce", {
     regexp = "object that can be coerced"
   )
 })
+
+test_that(".is_sorted works", {
+  expect_true(.is_sorted(1:3))
+  expect_true(.is_sorted(c("a", "b", "c")))
+  expect_true(.is_sorted(factor(c("a", "b", "c"))))
+
+  expect_false(.is_sorted(c(1, 3, 2)))
+  expect_false(.is_sorted(c("b", "a", "c")))
+  expect_false(.is_sorted(factor(c("b", "a", "c"))))
+})


### PR DESCRIPTION
No need to waste time if data is already sorted. This can save some time on large datasets but only works when there's only one variable used to arrange the data