### PR TITLE
Modify attributes replacement for performance gains

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ MINOR CHANGES
 
 * When column names are misspelled, most functions now suggest which
   existing columns possibly could be meant.
+  
+* Miscellaneous performance gains.
 
 # datawizard 0.6.2
 

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -319,6 +319,8 @@ categorize.grouped_df <- function(x,
   # works only for dplyr >= 0.8.0
   grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
 
+  attr_data <- attributes(x)
+
   # evaluate arguments
   select <- .select_nse(select,
     x,
@@ -353,7 +355,7 @@ categorize.grouped_df <- function(x,
     )
   }
   # set back class, so data frame still works with dplyr
-  x <- .replace_attrs(x, attributes(x))
+  x <- .replace_attrs(x, attr_data)
   x
 }
 

--- a/R/categorize.R
+++ b/R/categorize.R
@@ -315,7 +315,6 @@ categorize.grouped_df <- function(x,
                                   regex = FALSE,
                                   verbose = TRUE,
                                   ...) {
-  info <- attributes(x)
 
   # works only for dplyr >= 0.8.0
   grps <- attr(x, "groups", exact = TRUE)[[".rows"]]
@@ -354,7 +353,7 @@ categorize.grouped_df <- function(x,
     )
   }
   # set back class, so data frame still works with dplyr
-  attributes(x) <- utils::modifyList(info, attributes(x))
+  x <- .replace_attrs(x, attributes(x))
   x
 }
 

--- a/R/data_merge.R
+++ b/R/data_merge.R
@@ -172,9 +172,7 @@ data_join <- data_merge
 #' @rdname data_merge
 #' @export
 data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, verbose = TRUE, ...) {
-  # save data frame attributes
-  attr_x <- attributes(x)
-  attr_y <- attributes(y)
+
   class_x <- class(x)
 
   # save variable attributes
@@ -312,8 +310,8 @@ data_merge.data.frame <- function(x, y, join = "left", by = NULL, id = NULL, ver
   out <- out[all_columns]
 
   # add back attributes
-  attributes(out) <- utils::modifyList(attr_y, attributes(out))
-  attributes(out) <- utils::modifyList(attr_x, attributes(out))
+  out <- .replace_attrs(out, attributes(y))
+  out <- .replace_attrs(out, attributes(x))
 
   for (i in colnames(out)) {
     if (is.list(attr_vars[[i]])) {

--- a/R/data_relocate.R
+++ b/R/data_relocate.R
@@ -84,7 +84,7 @@ data_relocate <- function(data,
   )
 
   # save attributes
-  att <- attributes(data)
+  attr_data <- attributes(data)
 
   # Move columns to the right hand side
   data <- data[c(setdiff(names(data), cols), cols)]
@@ -132,7 +132,7 @@ data_relocate <- function(data,
   position <- position[position <= length(data_cols)]
 
   out <- data[position]
-  attributes(out) <- utils::modifyList(att, attributes(out))
+  out <- .replace_attrs(out, attr_data)
 
   out
 }
@@ -158,6 +158,6 @@ data_reorder <- function(data,
   remaining_columns <- setdiff(colnames(data), cols)
 
   out <- data[c(cols, remaining_columns)]
-  attributes(out) <- utils::modifyList(attributes(data), attributes(out))
+  out <- .replace_attrs(out, attributes(data))
   out
 }

--- a/R/data_remove.R
+++ b/R/data_remove.R
@@ -29,9 +29,8 @@ data_remove <- function(data,
     return(data)
   }
 
-  new <- data[!colnames(data) %in% select]
-  attributes(new) <- utils::modifyList(attributes(data), attributes(new))
-  class(new) <- class(data)
+  out <- data[!colnames(data) %in% select]
+  out <- .replace_attrs(out, attributes(data))
 
-  new
+  out
 }

--- a/R/data_rotate.R
+++ b/R/data_rotate.R
@@ -43,7 +43,7 @@
 #' @export
 data_rotate <- function(data, rownames = NULL, colnames = FALSE, verbose = TRUE) {
   # copy attributes
-  a <- attributes(data)
+  attr_data <- attributes(data)
 
   # check if first column has column names to be used for rotated data
   if (isTRUE(colnames)) {
@@ -65,31 +65,27 @@ data_rotate <- function(data, rownames = NULL, colnames = FALSE, verbose = TRUE)
   }
 
   # rotate data frame by 90 degrees
-  data <- as.data.frame(t(as.data.frame(data)))
+  out <- as.data.frame(t(as.data.frame(data)))
 
   # add column names, if requested
   if (!is.null(colnames)) {
     # check if we have correct length of column names
-    if (length(colnames) != ncol(data)) {
+    if (length(colnames) != ncol(out)) {
       warning(
         "Length of provided column names does not match number of columns. No column names changed.",
         call. = FALSE
       )
     } else {
-      colnames(data) <- colnames
+      colnames(out) <- colnames
     }
   }
 
   # add rownames as a new column, if requested
-  if (!is.null(rownames)) data <- rownames_as_column(data, var = rownames)
+  if (!is.null(rownames)) out <- rownames_as_column(out, var = rownames)
 
-  # delete the common attributes
-  a[names(a) %in% names(attributes(data))] <- NULL
+  out <- .replace_attrs(out, attr_data)
 
-  # and then add other attributes to the data frame
-  attributes(data) <- utils::modifyList(attributes(data), a)
-
-  data
+  out
 }
 
 

--- a/R/remove_empty.R
+++ b/R/remove_empty.R
@@ -105,9 +105,9 @@ remove_empty_rows <- function(x) {
 
   # if yes, removing works, else an empty df would be returned
   if (length(er)) {
-    att <- attributes(x)
+    attr_data <- attributes(x)
     x <- x[-er, ]
-    attributes(x) <- utils::modifyList(att, attributes(x))
+    x <- .replace_attrs(x, attr_data)
   }
 
   x

--- a/R/utils.R
+++ b/R/utils.R
@@ -121,3 +121,19 @@
 #' @noRd
 
 .is_sorted <- Negate(is.unsorted)
+
+
+#' Replace only custom attributes
+#'
+#' Using "attributes(out) <- attributes(data)" or similar doesn't work so well
+#' for big datasets because it takes some time to attribute the row names.
+#'
+#' This function gives only custom attributes to the new dataset.
+#' @noRd
+
+.replace_attrs <- function(data, custom_attr) {
+  for(nm in setdiff(names(custom_attr), names(attributes(data.frame())))) {
+    attr(data, which = nm) <- custom_attr[[nm]]
+  }
+  return(data)
+}

--- a/tests/testthat/test-data_relocate.R
+++ b/tests/testthat/test-data_relocate.R
@@ -80,7 +80,8 @@ test_that("data_relocate preserves attributes", {
   out2 <- data_relocate(out, 4:6)
   a2 <- attributes(out2)
 
-  expect_equal(names(a1), names(a2))
+  # attributes may not be in the same order
+  expect_true(all(names(a1) %in% names(a2)) && length(a1) == length(a2))
 })
 
 

--- a/tests/testthat/test-data_remove.R
+++ b/tests/testthat/test-data_remove.R
@@ -117,7 +117,8 @@ test_that("data_remove preserves attributes", {
   out2 <- data_remove(out, "SE")
   a2 <- attributes(out2)
 
-  expect_equal(names(a1), names(a2))
+  # attributes may not be in the same order
+  expect_true(all(names(a1) %in% names(a2)) && length(a1) == length(a2))
 })
 
 # select helpers ------------------------------

--- a/tests/testthat/test-data_reorder.R
+++ b/tests/testthat/test-data_reorder.R
@@ -23,5 +23,6 @@ test_that("data_reorder preserves attributes", {
   out2 <- data_reorder(out, 4:6)
   a2 <- attributes(out2)
 
-  expect_equal(names(a1), names(a2))
+  # attributes may not be in the same order
+  expect_true(all(names(a1) %in% names(a2)) && length(a1) == length(a2))
 })


### PR DESCRIPTION
Some functions should be fast whatever the size of the dataframe, such as `data_relocate()` or `data_reorder()` since it's just about moving columns. However, the way attributes are applied back to the modified dataframe leads to a loss of performance because it also reallocates the row names (see [this SO answer](https://stackoverflow.com/questions/74029805/why-does-adding-attributes-to-a-dataframe-take-longer-with-large-dataframes)). When there are millions of rows, this takes some time. Therefore, we should only reallocate the attributes that are "unusual" for a dataframe. This is done in `.replace_attrs()`.

Current (takes more time for large dataset but it shouldn't):
``` r
library(datawizard)

tmp <- data.frame(x = sample(1:10, size = 2, replace = TRUE),
                   y = sample(1:10, size = 2, replace = TRUE))

tmp2 <- data.frame(x = sample(1:10, size = 1e7, replace = TRUE),
                  y = sample(1:10, size = 1e7, replace = TRUE))

bench::mark(
  datawiz_small = data_relocate(tmp, "x", after = -1),
  datawiz_big = data_relocate(tmp2, "x", after = -1),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawiz_small  300.1µs  390.1µs    2048.    394.1KB    12.5 
#> 2 datawiz_big     57.9ms   64.5ms      15.1    38.1MB     7.54

bench::mark(
  datawiz_small = data_reorder(tmp, "x"),
  datawiz_big = data_reorder(tmp2, "x"),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawiz_small  247.4µs  330.2µs    2229.       12KB    13.0 
#> 2 datawiz_big     50.1ms   59.2ms      15.9    38.1MB     2.66
```

New:
``` r
library(datawizard)

tmp <- data.frame(x = sample(1:10, size = 2, replace = TRUE),
                   y = sample(1:10, size = 2, replace = TRUE))

tmp2 <- data.frame(x = sample(1:10, size = 1e7, replace = TRUE),
                  y = sample(1:10, size = 1e7, replace = TRUE))

bench::mark(
  datawiz_small = data_relocate(tmp, "x", after = -1),
  datawiz_big = data_relocate(tmp2, "x", after = -1),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawiz_small    311µs    380µs     2093.     747KB     14.8
#> 2 datawiz_big      314µs    384µs     2002.      640B     12.7

bench::mark(
  datawiz_small = data_reorder(tmp, "x"),
  datawiz_big = data_reorder(tmp2, "x"),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 datawiz_small    252µs    317µs     2335.    18.6KB     12.6
#> 2 datawiz_big      252µs    328µs     2356.      640B     14.9
```



