### PR TITLE
data_to_wide: remove check names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.2.3
+Version: 0.6.2.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -311,7 +311,8 @@ data_to_wide <- function(data,
         res[[1]],
         nrow = 1, dimnames = list(c(), names(res[[1]]))
       ),
-      stringsAsFactors = FALSE
+      stringsAsFactors = FALSE,
+      check.names = FALSE
     )
   } else {
     res <- unlist(res, recursive = FALSE)
@@ -320,67 +321,9 @@ data_to_wide <- function(data,
   # return the wide data and the order in which the new columns should be
 
   list(
-    out = data.frame(res, stringsAsFactors = FALSE),
+    out = data.frame(res, stringsAsFactors = FALSE, check.names = FALSE),
     col_order = unique(x$future_colnames)
   )
-}
-
-
-
-#' Taken from https://github.com/coolbutuseless/gluestick
-#' Same functionality as `{glue}`
-#'
-#' @noRd
-
-.gluestick <- function(fmt, src = parent.frame(), open = "{", close = "}", eval = TRUE) {
-  nchar_open <- nchar(open)
-  nchar_close <- nchar(close)
-
-  # Sanity checks
-  stopifnot(exprs = {
-    is.character(fmt)
-    length(fmt) == 1L
-    is.character(open)
-    length(open) == 1L
-    nchar_open > 0L
-    is.character(close)
-    length(close) == 1
-    nchar_close > 0
-  })
-
-  # Brute force the open/close characters into a regular expression for
-  # extracting the expressions from the format string
-  open <- gsub("(.)", "\\\\\\1", open) # Escape everything!!
-  close <- gsub("(.)", "\\\\\\1", close) # Escape everything!!
-  re <- paste0(open, ".*?", close)
-
-  # Extract the delimited expressions
-  matches <- gregexpr(re, fmt)
-  exprs <- regmatches(fmt, matches)[[1]]
-
-  # Remove the delimiters
-  exprs <- substr(exprs, nchar_open + 1L, nchar(exprs) - nchar_close)
-
-  # create a valid sprintf fmt string.
-  #  - replace all "{expr}" strings with "%s"
-  #  - escape any '%' so sprintf() doesn't try and use them for formatting
-  #    but only if the '%' is NOT followed by an 's'
-  #
-  # gluestick() doesn't deal with any pathological cases
-  fmt_sprintf <- gsub(re, "%s", fmt)
-  fmt_sprintf <- gsub("%(?!s)", "%%", fmt_sprintf, perl = TRUE)
-
-  # Evaluate
-  if (eval) {
-    args <- lapply(exprs, function(expr) {
-      eval(parse(text = expr), envir = src)
-    })
-  } else {
-    args <- unname(mget(exprs, envir = as.environment(src)))
-  }
-
-  # Create the string(s)
-  do.call(sprintf, c(list(fmt_sprintf), args))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -144,7 +144,7 @@
 }
 
 
-#' Taken from https://github.com/coolbutuseless/gluestick
+#' Taken from https://github.com/coolbutuseless/gluestick [licence: MIT]
 #' Same functionality as `{glue}`
 #'
 #' @noRd

--- a/tests/testthat/test-data_reshape.R
+++ b/tests/testthat/test-data_reshape.R
@@ -824,3 +824,24 @@ test_that("#293", {
     data_to_wide(daily, names_from = "day", values_from = "value")
   )
 })
+
+
+test_that("new names starting with digits are not corrected automatically", {
+  percentages <- tibble(
+    year = c(2018, 2019, 2020, 2020),
+    type = factor(c("A", "B", "A", "B"), levels = c("A", "B")),
+    percentage = c(100, 100, 40, 60)
+  )
+
+  tidyr <- tidyr::pivot_wider(
+    percentages,
+    names_from = c(year, type),
+    values_from = percentage,
+  )
+  datawiz <- data_to_wide(
+    percentages,
+    names_from = c("year", "type"),
+    values_from = "percentage",
+  )
+  expect_identical(tidyr, datawiz)
+})


### PR DESCRIPTION
The example below causes an error because `data.frame()` adds an "X" in front of column names if they start with a number, so I remove this behavior

Before:
``` r
percentages <- tidyr::tibble(
  year = c(2018, 2019, 2020, 2020),
  type = factor(c("A", "B", "A", "B"), levels = c("A", "B")),
  percentage = c(100, 100, 40, 60)
)

percentages
#> # A tibble: 4 × 3
#>    year type  percentage
#>   <dbl> <fct>      <dbl>
#> 1  2018 A            100
#> 2  2019 B            100
#> 3  2020 A             40
#> 4  2020 B             60

tidyr::pivot_wider(
  percentages,
  names_from = c(year, type),
  values_from = percentage,
)
#> # A tibble: 1 × 4
#>   `2018_A` `2019_B` `2020_A` `2020_B`
#>      <dbl>    <dbl>    <dbl>    <dbl>
#> 1      100      100       40       60

datawizard::data_to_wide(
  percentages,
  names_from = c("year", "type"),
  values_from = "percentage",
)
#> Error in `[.data.frame`(out, , unstacked$col_order): undefined columns selected
```

After:
``` r
datawizard::data_to_wide(
  percentages,
  names_from = c("year", "type"),
  values_from = "percentage",
)
#> # A tibble: 1 × 4
#>   `2018_A` `2019_B` `2020_A` `2020_B`
#>      <dbl>    <dbl>    <dbl>    <dbl>
#> 1      100      100       40       60
```



