### PR TITLE
Fix failing case in `data_to_wide`

### DIFF
--- a/tests/testthat/test-data_reshape.R
+++ b/tests/testthat/test-data_reshape.R
@@ -482,6 +482,34 @@ test_that("error when overwriting existing column", {
   )
 })
 
+test_that("data_to_wide: fill values, #293", {
+  skip_if_not_installed("tidyr")
+  library(tidyr)
+
+  weekdays <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+  daily <- tibble(
+    day = factor(c("Tue", "Thu", "Fri", "Mon"), levels = weekdays),
+    value = c(2, 3, 1, 5),
+    type = factor(c("A", "B", "B", "A"))
+  )
+
+  expect_identical(
+    pivot_wider(
+      daily,
+      names_from = type,
+      values_from = value,
+      values_fill = 0
+    ),
+    data_to_wide(
+      daily,
+      names_from = "type",
+      values_from = "value",
+      values_fill = 0
+    )
+  )
+})
+
 
 ### Examples from tidyr website
 


### PR DESCRIPTION
Related to #293. The rewriting I did in reshaping functions starts to become a mess, I will try to improve it later but at least the example is now fixed.

@IndrajeetPatil if the tests pass, then I'm ok to make the release with the patch for R-devel. I found other situations where the reshaping functions don't match 100% the output of `tidyr` (see #293) but our previous reshaping functions also failed so it's not due to the rewriting. I can take care of these later.