### PR TITLE
`data_to_wide`: drop cols that are not in `id_cols` (if specified), `names_from` or `values_from`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.3
+Version: 0.6.3.1
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# datawizard (devel)
+
+BUG FIXES
+
+* `data_to_wide()` now drops columns that are not in `id_cols` (if specified), 
+  `names_from`, or `values_from`. This is the behaviour observed in `tidyr::pivot_wider()`.
+  
+
 # datawizard 0.6.3
 
 MAJOR CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # datawizard (devel)
 
-BUG FIXES
+BUG FIXES 
 
 * `data_to_wide()` now drops columns that are not in `id_cols` (if specified), 
   `names_from`, or `values_from`. This is the behaviour observed in `tidyr::pivot_wider()`.

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -142,9 +142,9 @@ data_to_wide <- function(data,
 
   # create an id with all variables that are not in names_from or values_from
   # so that we can create missing combinations between this id and names_from
-  if (length(id_cols) > 1) {
+  if (length(id_cols) > 1L) {
     new_data$temporary_id <- do.call(paste, c(new_data[, id_cols, drop = FALSE], sep = "_"))
-  } else if (length(id_cols) == 1) {
+  } else if (length(id_cols) == 1L) {
     new_data$temporary_id <- new_data[[id_cols]]
   } else {
     new_data$temporary_id <- seq_len(nrow(new_data))
@@ -156,7 +156,7 @@ data_to_wide <- function(data,
   n_rows_per_group <- table(new_data$temporary_id)
   n_values_per_group <- insight::n_unique(n_rows_per_group)
 
-  not_all_cols_are_selected <- length(id_cols) > 0
+  not_all_cols_are_selected <- length(id_cols) > 0L
 
   incomplete_groups <-
     (n_values_per_group > 1 &&

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -115,6 +115,11 @@ data_to_wide <- function(data,
       names_sep <- sep
     }
   }
+  if (is.null(id_cols)) {
+    id_cols <- setdiff(names(data), c(names_from, values_from))
+  }
+
+
   current_colnames <- names(data)
 
   # Preserve attributes
@@ -127,8 +132,7 @@ data_to_wide <- function(data,
 
   variable_attr <- lapply(data, attributes)
 
-  not_selected <- setdiff(names(data), c(names_from, values_from))
-  not_unstacked <- data[, not_selected, drop = FALSE]
+  not_unstacked <- data[, id_cols, drop = FALSE]
   not_unstacked <- unique(not_unstacked)
 
   # unstack doesn't create NAs for combinations that don't exist (contrary to
@@ -138,10 +142,10 @@ data_to_wide <- function(data,
 
   # create an id with all variables that are not in names_from or values_from
   # so that we can create missing combinations between this id and names_from
-  if (length(not_selected) > 1) {
-    new_data$temporary_id <- do.call(paste, c(new_data[, not_selected, drop = FALSE], sep = "_"))
-  } else if (length(not_selected) == 1) {
-    new_data$temporary_id <- new_data[[not_selected]]
+  if (length(id_cols) > 1) {
+    new_data$temporary_id <- do.call(paste, c(new_data[, id_cols, drop = FALSE], sep = "_"))
+  } else if (length(id_cols) == 1) {
+    new_data$temporary_id <- new_data[[id_cols]]
   } else {
     new_data$temporary_id <- seq_len(nrow(new_data))
   }
@@ -152,7 +156,7 @@ data_to_wide <- function(data,
   n_rows_per_group <- table(new_data$temporary_id)
   n_values_per_group <- insight::n_unique(n_rows_per_group)
 
-  not_all_cols_are_selected <- length(not_selected) > 0
+  not_all_cols_are_selected <- length(id_cols) > 0
 
   incomplete_groups <-
     (n_values_per_group > 1 &&
@@ -194,7 +198,7 @@ data_to_wide <- function(data,
 
     # creation of missing combinations was done with a temporary id, so need
     # to fill columns that are not selected in names_from or values_from
-    new_data[, not_selected] <- lapply(not_selected, function(x) {
+    new_data[, id_cols] <- lapply(id_cols, function(x) {
       data <- data_arrange(new_data, c("temporary_id_2", x))
       ind <- which(!is.na(data[[x]]))
       rep_times <- diff(c(ind, length(data[[x]]) + 1))

--- a/tests/testthat/test-data_reshape.R
+++ b/tests/testthat/test-data_reshape.R
@@ -510,6 +510,33 @@ test_that("data_to_wide: fill values, #293", {
   )
 })
 
+test_that("data_to_wide, id_cols works correctly, #293", {
+  skip_if_not_installed("tidyr")
+  library(tidyr)
+
+  updates <- tibble(
+    county = c("Wake", "Wake", "Wake", "Guilford", "Guilford"),
+    date = c(as.Date("2020-01-01") + 0:2, as.Date("2020-01-03") + 0:1),
+    system = c("A", "B", "C", "A", "C"),
+    value = c(3.2, 4, 5.5, 2, 1.2)
+  )
+
+  expect_identical(
+    pivot_wider(
+      updates,
+      id_cols = county,
+      names_from = system,
+      values_from = value
+    ),
+    data_to_wide(
+      updates,
+      id_cols = "county",
+      names_from = "system",
+      values_from = "value"
+    )
+  )
+})
+
 
 ### Examples from tidyr website
 


### PR DESCRIPTION
Close #293 