### PR TITLE
Add big mark also to counts in headers

### DIFF
--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -232,15 +232,22 @@ format.dw_data_tabulate <- function(x, format = "text", big_mark = NULL, ...) {
   ftab$N <- gsub("\\.00$", "", ftab$N)
 
   # insert big marks?
-  if (is.null(big_mark) && any(nchar(ftab$N) > 5)) {
-    big_mark <- ","
-  }
-  if (!is.null(big_mark)) {
-    ftab$N <- prettyNum(ftab$N, big.mark = big_mark)
-  }
+  ftab$N <- .add_commas_in_numbers(ftab$N, big_mark)
 
   ftab
 }
+
+.add_commas_in_numbers <- function(x, big_mark = NULL) {
+  if (is.null(big_mark) && any(nchar(x) > 5)) {
+    big_mark <- ","
+  }
+  if (!is.null(big_mark)) {
+    x <- prettyNum(x, big.mark = big_mark)
+  }
+
+  x
+}
+
 
 
 #' @export
@@ -259,8 +266,11 @@ print.dw_data_tabulate <- function(x, big_mark = NULL, ...) {
     cat("\n")
   }
 
+  a$total_n <- .add_commas_in_numbers(a$total_n, big_mark)
+  a$valid_n <- .add_commas_in_numbers(a$valid_n, big_mark)
+
   # summary of total and valid N (we may add mean/sd as well?)
-  summary_line <- sprintf("# total N=%i valid N=%i\n\n", a$total_n, a$valid_n)
+  summary_line <- sprintf("# total N=%s valid N=%s\n\n", a$total_n, a$valid_n)
   cat(insight::print_color(summary_line, "blue"))
 
   # remove information that goes into the header/footer

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -166,7 +166,7 @@ test_that("data_tabulate big numbers", {
     out,
     c(
       "x <integer>",
-      "# total N=10000000 valid N=10000000",
+      "# total N=10,000,000 valid N=10,000,000",
       "",
       "Value |         N | Raw % | Valid % | Cumulative %",
       "------+-----------+-------+---------+-------------",
@@ -200,7 +200,7 @@ test_that("data_tabulate big numbers", {
     out,
     c(
       "x <integer>",
-      "# total N=10000000 valid N=10000000",
+      "# total N=10-000-000 valid N=10-000-000",
       "",
       "Value |         N | Raw % | Valid % | Cumulative %",
       "------+-----------+-------+---------+-------------",


### PR DESCRIPTION
Closes #315

``` r
datawizard::data_tabulate(openintro::military$grade)
#> openintro::military$grade <categorical>
#> # total N=1,414,593 valid N=1,414,593
#> 
#> Value           |         N | Raw % | Valid % | Cumulative %
#> ----------------+-----------+-------+---------+-------------
#> enlisted        | 1,183,889 | 83.69 |   83.69 |        83.69
#> officer         |   211,525 | 14.95 |   14.95 |        98.64
#> warrant officer |    19,179 |  1.36 |    1.36 |       100.00
#> <NA>            |         0 |  0.00 |    <NA> |         <NA>
```

<sup>Created on 2022-11-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>