### PR TITLE
Fix `center()` when only one value and `reference` or `center` specified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.4.2
+Version: 0.6.4.3
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 * Etienne Bacher is the new maintainer.
 
+BUG FIXES
+
+* `center(x)` now works correctly when `x` is a single value and either
+  `reference` or `center` is specified (#324).
+
 # datawizard 0.6.4
 
 NEW FUNCTIONS

--- a/R/utils_standardize_center.R
+++ b/R/utils_standardize_center.R
@@ -31,7 +31,7 @@
 
 
   # Sanity checks
-  check <- .check_standardize_numeric(x, name = NULL, verbose = verbose, reference = reference)
+  check <- .check_standardize_numeric(x, name = NULL, verbose = verbose, reference = reference, center = center)
 
   if (is.factor(vals) || is.character(vals)) {
     vals <- .factor_to_numeric(vals)
@@ -210,6 +210,7 @@
   } else {
     center <- weighted_mean(reference, weights)
     scale <- weighted_sd(reference, weights)
+    if (is.na(scale)) scale <- 1
   }
 
   if (scale == 0) {
@@ -231,9 +232,10 @@
 .check_standardize_numeric <- function(x,
                                        name = NULL,
                                        verbose = TRUE,
-                                       reference = NULL) {
+                                       reference = NULL,
+                                       center) {
   # Warning if only one value
-  if (insight::has_single_value(x) && is.null(reference)) {
+  if (insight::has_single_value(x) && is.null(reference) && is.null(center)) {
     if (verbose) {
       if (is.null(name)) {
         insight::format_alert(

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -58,6 +58,17 @@ test_that("center, all NA or Inf", {
   expect_equal(z, c(NA, -Inf, Inf), ignore_attr = TRUE)
 })
 
+test_that("center works correctly with only one value", {
+  expect_equal(center(100), 0, ignore_attr = TRUE)
+  expect_message(center(100), "will be set to 0")
+  expect_equal(center(100, center = 1), 99, ignore_attr = TRUE)
+  expect_equal(
+    center(100, reference = mtcars$mpg),
+    100 - mean(mtcars$mpg),
+    ignore_attr = TRUE
+  )
+})
+
 
 
 # with grouped data -------------------------------------------


### PR DESCRIPTION
Close #324

``` r
library(datawizard)

x <- 1:4
M <- mean(x)

center(x, center = M)
#> [1] -1.5 -0.5  0.5  1.5
#> attr(,"center")
#> [1] 2.5
#> attr(,"scale")
#> [1] 1
#> attr(,"robust")
#> [1] FALSE
center(100, center = M)
#> [1] 97.5
#> attr(,"center")
#> [1] 2.5
#> attr(,"scale")
#> [1] 1
#> attr(,"robust")
#> [1] FALSE
center(100)
#> The variable contains only one unique value and will be set to 0.
#> [1] 0
#> attr(,"center")
#> [1] 100
#> attr(,"scale")
#> [1] 1
#> attr(,"robust")
#> [1] FALSE
```

@mattansb can you confirm this is the expected behavior (and check the tests)?