### PR TITLE
Add a roadmap to the website?

### DIFF
--- a/_pkgdown.yaml
+++ b/_pkgdown.yaml
@@ -129,3 +129,9 @@ articles:
     navbar: ~
     contents:
       - standardize_data
+
+navbar:
+  right:
+  - text: "Roadmap"
+    href: articles/roadmap.html
+    icon: fa-solid fa-map

--- a/vignettes/roadmap.Rmd
+++ b/vignettes/roadmap.Rmd
@@ -1,0 +1,37 @@
+---
+title: "Roadmap"
+output: 
+  rmarkdown::html_vignette:
+    toc: true
+    fig_width: 10.08
+    fig_height: 6
+vignette: >
+  \usepackage[utf8]{inputenc}
+  %\VignetteIndexEntry{Roadmap}
+  %\VignetteEngine{knitr::rmarkdown}
+---
+
+Current version of `datawizard`: `r packageVersion("datawizard")`
+
+## What is left to do before 1.0.0?
+
+The `datawizard` package has evolved a lot since its creation in May 2021. A lot
+of functions were added, and many of them changed names as we were trying to 
+implement a consistent interface.
+
+Version 1.0.0 will be the first **stable** version. Before reaching version 1.0.0,
+the following objectives need to be reached:
+
+* **stability**: function and arguments names should be stable and consistent
+  across the package;
+  
+* **robustness**: the source code of the package should be revised to ensure it
+  follows best practices in terms of stability and consistency;
+  
+* **speed**: functions should be as fast as possible, while respecting the 
+  constraint that everything should be written in base R (no C++, no dependencies 
+  other than other *easystats* packages).
+  
+
+Do you want more details or to add something to this roadmap? Check out the [list
+of issues](github.com/easystats/datawizard/issues) on Github.


### PR DESCRIPTION
As discussed in https://github.com/easystats/easystats/issues/330, here's an example of roadmap for `datawizard`. This is just some "placeholder" text so that we can explore if and how we want to add this to the website (how detailed should be the content of this roadmap?, etc.).

Feel free to modify, this is not meant to be merged as-is. Here's what it looks like:

![image](https://user-images.githubusercontent.com/52219252/207853635-1d2db835-5098-45b8-85df-7f08c7e188ad.png)

![image](https://user-images.githubusercontent.com/52219252/207853880-73f78ec0-bab7-49d5-b0a7-770cdeda8ef7.png)

@rempsyc @IndrajeetPatil WDYT?