### PR TITLE
Silence the messages in tests

### DIFF
--- a/R/categorize.R
+++ b/R/categorize.R
@@ -181,7 +181,7 @@ categorize.numeric <- function(x,
   # stop if all NA
   if (!length(x)) {
     if (isTRUE(verbose)) {
-      insight::format_warning(
+      insight::format_alert(
         "Variable contains only missing values. No recoding carried out."
       )
     }

--- a/R/demean.R
+++ b/R/demean.R
@@ -326,12 +326,12 @@ degroup <- function(x,
     }
     # tell user...
     if (isTRUE(verbose)) {
-      insight::print_color(
-        sprintf(
-          "Categorical predictors (%s) have been coerced to numeric values to compute de- and group-meaned variables.\n",
-          toString(names(categorical_predictors)[categorical_predictors])
-        ),
-        "yellow"
+      insight::format_alert(
+        paste0(
+          "Categorical predictors (",
+          toString(names(categorical_predictors)[categorical_predictors]),
+          ") have been coerced to numeric values to compute de- and group-meaned variables.\n"
+        )
       )
     }
   }

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -121,7 +121,7 @@ test_that("to_numeric, attributes preserved", {
 test_that("convert_to_na, attributes preserved", {
   x <- iris
   attr(x, "myattri") <- "I'm here"
-  x2 <- convert_to_na(x, na = 2)
+  x2 <- convert_to_na(x, na = 2, verbose = FALSE)
   expect_identical(attr(x2, "myattri", exact = TRUE), "I'm here")
 })
 
@@ -130,7 +130,7 @@ test_that("convert_to_na, attributes preserved", {
 # data_rename -----------------------------------
 
 test_that("data_rename, attributes preserved", {
-  x <- iris
+  x <- mtcars
   attr(x, "myattri") <- "I'm here"
   x2 <- data_rename(x, pattern = "hp", replacement = "horsepower")
   expect_identical(attr(x2, "myattri", exact = TRUE), "I'm here")

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -59,8 +59,12 @@ test_that("center, all NA or Inf", {
 })
 
 test_that("center works correctly with only one value", {
-  expect_equal(center(100), 0, ignore_attr = TRUE)
-  expect_message(center(100), "will be set to 0")
+  expect_message(
+    x <- center(100),
+    "will be set to 0"
+  )
+  expect_equal(x, 0, ignore_attr = TRUE)
+
   expect_equal(center(100, center = 1), 99, ignore_attr = TRUE)
   expect_equal(
     center(100, reference = mtcars$mpg),

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -30,7 +30,7 @@ test_that("center, select", {
 
 test_that("center, factors", {
   z <- center(iris, select = "Species")
-  expect_equal(z$Species, iris$Species)
+  expect_identical(z$Species, iris$Species)
 })
 
 test_that("center, force factors", {
@@ -45,7 +45,7 @@ test_that("center, force factors", {
 
 test_that("center, all na", {
   z <- center(c(NA, NA, NA))
-  expect_equal(z, c(NA, NA, NA))
+  expect_identical(z, c(NA, NA, NA))
 })
 
 test_that("center, with Inf", {
@@ -93,7 +93,7 @@ test_that("center (grouped data)", {
     ungroup() %>%
     pull(Sepal.Width)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 test_that("center, robust (grouped data)", {
@@ -112,7 +112,7 @@ test_that("center, robust (grouped data)", {
     ungroup() %>%
     pull(Sepal.Width)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 test_that("center, select (grouped data)", {
@@ -131,7 +131,7 @@ test_that("center, select (grouped data)", {
     ungroup() %>%
     pull(Sepal.Width)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 test_that("center, factors (grouped data)", {
@@ -147,16 +147,16 @@ test_that("center, factors (grouped data)", {
   manual <- iris %>%
     pull(Species)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 # select helpers ------------------------------
 test_that("center regex", {
-  expect_equal(
+  expect_identical(
     center(mtcars, select = "pg", regex = TRUE)$mpg,
     center(mtcars$mpg)
   )
-  expect_equal(
+  expect_identical(
     center(mtcars, select = "pg$", regex = TRUE)$mpg,
     center(mtcars$mpg)
   )

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -126,4 +126,3 @@ test_that("convert_to_na regex", {
     convert_to_na(mtcars, na = 4, select = "carb")
   )
 })
-

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -52,7 +52,13 @@ test_that("convert_to_na-df", {
     x <- convert_to_na(iris, na = 3),
     "needs to be a character vector"
   )
-  expect_identical(sum(is.na(x)), sum(vapply(iris, function(i) if (is.numeric(i)) sum(i == 3) else 0L, FUN.VALUE = integer(1L))))
+  expect_identical(sum(is.na(x)), sum(vapply(iris, function(i) {
+    if (is.numeric(i)) {
+      sum(i == 3)
+    } else {
+      0L
+    }
+  }, FUN.VALUE = integer(1L))))
 
   x <- convert_to_na(iris, na = list(3, "3"))
   expect_identical(sum(is.na(x)), 27L)
@@ -70,30 +76,35 @@ test_that("convert_to_na other classes", {
 
   x <- convert_to_na(d$a, na = 3)
   expect_equal(x, c(1, 2, NA, 4, 5), tolerance = 1e-3, ignore_attr = TRUE)
-  expect_message(
-    x <- convert_to_na(d$a, na = "c"),
-    "needs to be a numeric vector"
-  )
+  expect_message(x <- convert_to_na(d$a, na = "c"), "needs to be a numeric vector")
   expect_equal(x, 1:5, tolerance = 1e-3, ignore_attr = TRUE)
 
   x <- convert_to_na(d$b, na = "c")
-  expect_equal(x, structure(c(1L, 2L, NA, 4L, 5L),
-    .Label = c("a", "b", "c", "d", "e"),
-    class = "factor"
-  ), tolerance = 1e-3, ignore_attr = TRUE)
+  expect_equal(
+    x,
+    structure(c(1L, 2L, NA, 4L, 5L), .Label = c("a", "b", "c", "d", "e"), class = "factor"),
+    tolerance = 1e-3,
+    ignore_attr = TRUE
+  )
 
   x <- convert_to_na(d$b, na = "c", drop_levels = TRUE)
-  expect_equal(x, structure(c(1L, 2L, NA, 3L, 4L),
-    .Label = c("a", "b", "d", "e"),
-    class = "factor"
-  ), tolerance = 1e-3, ignore_attr = TRUE)
+  expect_equal(
+    x,
+    structure(c(1L, 2L, NA, 3L, 4L), .Label = c("a", "b", "d", "e"), class = "factor"),
+    tolerance = 1e-3,
+    ignore_attr = TRUE
+  )
 
   expect_message(
     convert_to_na(d$c, na = "2022-03-22"),
     "of class 'Date'"
   )
   x <- convert_to_na(d$c, na = as.Date("2022-03-22"))
-  expect_equal(x, structure(c(NA, 18994, 19025, 18719, 18280), class = "Date"), tolerance = 1e-3, ignore_attr = TRUE)
+  expect_equal(x,
+    structure(c(NA, 18994, 19025, 18719, 18280), class = "Date"),
+    tolerance = 1e-3,
+    ignore_attr = TRUE
+  )
 
   x <- convert_to_na(d$d, na = TRUE)
   expect_equal(x, c(NA, NA, FALSE, FALSE, NA), tolerance = 1e-3, ignore_attr = TRUE)

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -2,39 +2,39 @@ data(iris)
 
 test_that("convert_to_na-factor", {
   x <- convert_to_na(iris$Species, na = "versicolor")
-  expect_equal(sum(is.na(x)), 50)
+  expect_identical(sum(is.na(x)), 50L)
 
   x <- convert_to_na(iris$Species, na = list(2, "versicolor"))
-  expect_equal(sum(is.na(x)), 50)
+  expect_identical(sum(is.na(x)), 50L)
 
   x <- convert_to_na(iris$Species, na = list(2, "versicolor"), drop_levels = FALSE)
-  expect_equal(levels(x), c("setosa", "versicolor", "virginica"))
-  expect_equal(as.vector(table(x)), c(50, 0, 50))
+  expect_identical(levels(x), c("setosa", "versicolor", "virginica"))
+  expect_identical(as.vector(table(x)), c(50L, 0L, 50L))
 
   x <- convert_to_na(iris$Species, na = list(2, "versicolor"), drop_levels = TRUE)
-  expect_equal(levels(x), c("setosa", "virginica"))
-  expect_equal(as.vector(table(x)), c(50, 50))
+  expect_identical(levels(x), c("setosa", "virginica"))
+  expect_identical(as.vector(table(x)), c(50L, 50L))
 
   expect_message(
     x <- convert_to_na(iris$Species, na = 2),
     "for a factor or character variable"
   )
-  expect_equal(sum(is.na(x)), 0)
+  expect_identical(sum(is.na(x)), 0L)
 })
 
 test_that("convert_to_na-numeric", {
   x <- convert_to_na(iris$Sepal.Length, na = 5)
-  expect_equal(sum(is.na(x)), sum(iris$Sepal.Length == 5))
+  expect_identical(sum(is.na(x)), sum(iris$Sepal.Length == 5))
 
   x <- convert_to_na(iris$Sepal.Length, na = list(5, "versicolor"))
-  expect_equal(sum(is.na(x)), 10)
+  expect_identical(sum(is.na(x)), 10L)
 
   x <- convert_to_na(iris$Sepal.Width, na = "a", verbose = FALSE)
   expect_message(
     convert_to_na(iris$Sepal.Width, na = "a"),
     "needs to be a numeric vector"
   )
-  expect_equal(sum(is.na(x)), 0)
+  expect_identical(sum(is.na(x)), 0L)
 })
 
 test_that("convert_to_na-df", {
@@ -42,20 +42,20 @@ test_that("convert_to_na-df", {
     x <- convert_to_na(iris, na = 5),
     "needs to be a character vector"
   )
-  expect_equal(sum(is.na(x)), sum(sapply(iris, function(i) sum(i == 5))))
+  expect_identical(sum(is.na(x)), sum(vapply(iris, function(i) sum(i == 5), FUN.VALUE = integer(1L))))
 
   x <- convert_to_na(iris, na = list(5, "versicolor"))
-  expect_equal(sum(is.na(x)), 64)
+  expect_identical(sum(is.na(x)), 64L)
 
   data(iris)
   expect_message(
     x <- convert_to_na(iris, na = 3),
     "needs to be a character vector"
   )
-  expect_equal(sum(is.na(x)), sum(sapply(iris, function(i) if (is.numeric(i)) sum(i == 3) else 0)))
+  expect_identical(sum(is.na(x)), sum(vapply(iris, function(i) if (is.numeric(i)) sum(i == 3) else 0L, FUN.VALUE = integer(1L))))
 
   x <- convert_to_na(iris, na = list(3, "3"))
-  expect_equal(sum(is.na(x)), 27)
+  expect_identical(sum(is.na(x)), 27L)
 })
 
 
@@ -117,12 +117,13 @@ test_that("convert_to_na other classes", {
 
 # select helpers ------------------------------
 test_that("convert_to_na regex", {
-  expect_equal(
+  expect_identical(
     convert_to_na(mtcars, na = 4, select = "arb", regex = TRUE),
     convert_to_na(mtcars, na = 4, select = "carb")
   )
-  expect_equal(
+  expect_identical(
     convert_to_na(mtcars, na = 4, select = "arb$", regex = TRUE),
     convert_to_na(mtcars, na = 4, select = "carb")
   )
 })
+

--- a/tests/testthat/test-convert_to_na.R
+++ b/tests/testthat/test-convert_to_na.R
@@ -15,8 +15,10 @@ test_that("convert_to_na-factor", {
   expect_equal(levels(x), c("setosa", "virginica"))
   expect_equal(as.vector(table(x)), c(50, 50))
 
-  x <- suppressWarnings(convert_to_na(iris$Species, na = 2))
-  expect_message(convert_to_na(iris$Species, na = 2))
+  expect_message(
+    x <- convert_to_na(iris$Species, na = 2),
+    "for a factor or character variable"
+  )
   expect_equal(sum(is.na(x)), 0)
 })
 
@@ -27,21 +29,29 @@ test_that("convert_to_na-numeric", {
   x <- convert_to_na(iris$Sepal.Length, na = list(5, "versicolor"))
   expect_equal(sum(is.na(x)), 10)
 
-  x <- suppressWarnings(convert_to_na(iris$Sepal.Width, na = "a"))
-  expect_message(convert_to_na(iris$Sepal.Width, na = "a"))
+  x <- convert_to_na(iris$Sepal.Width, na = "a", verbose = FALSE)
+  expect_message(
+    convert_to_na(iris$Sepal.Width, na = "a"),
+    "needs to be a numeric vector"
+  )
   expect_equal(sum(is.na(x)), 0)
 })
 
 test_that("convert_to_na-df", {
-  expect_message(x <- convert_to_na(iris, na = 5))
+  expect_message(
+    x <- convert_to_na(iris, na = 5),
+    "needs to be a character vector"
+  )
   expect_equal(sum(is.na(x)), sum(sapply(iris, function(i) sum(i == 5))))
 
   x <- convert_to_na(iris, na = list(5, "versicolor"))
   expect_equal(sum(is.na(x)), 64)
 
   data(iris)
-  iris$Sepal.Width <- as.character(iris$Sepal.Width)
-  expect_message(expect_message(x <- convert_to_na(iris, na = 3)))
+  expect_message(
+    x <- convert_to_na(iris, na = 3),
+    "needs to be a character vector"
+  )
   expect_equal(sum(is.na(x)), sum(sapply(iris, function(i) if (is.numeric(i)) sum(i == 3) else 0)))
 
   x <- convert_to_na(iris, na = list(3, "3"))
@@ -60,7 +70,10 @@ test_that("convert_to_na other classes", {
 
   x <- convert_to_na(d$a, na = 3)
   expect_equal(x, c(1, 2, NA, 4, 5), tolerance = 1e-3, ignore_attr = TRUE)
-  expect_message(x <- convert_to_na(d$a, na = "c"))
+  expect_message(
+    x <- convert_to_na(d$a, na = "c"),
+    "needs to be a numeric vector"
+  )
   expect_equal(x, 1:5, tolerance = 1e-3, ignore_attr = TRUE)
 
   x <- convert_to_na(d$b, na = "c")
@@ -84,7 +97,10 @@ test_that("convert_to_na other classes", {
 
   x <- convert_to_na(d$d, na = TRUE)
   expect_equal(x, c(NA, NA, FALSE, FALSE, NA), tolerance = 1e-3, ignore_attr = TRUE)
-  expect_message(x <- convert_to_na(d$e, na = as.complex(4)))
+  expect_message(
+    x <- convert_to_na(d$e, na = as.complex(4)),
+    "variables of class `complex`"
+  )
   expect_equal(x, d$e, tolerance = 1e-3, ignore_attr = TRUE)
 
   out <- data.frame(
@@ -94,11 +110,8 @@ test_that("convert_to_na other classes", {
     d = c(NA, NA, FALSE, FALSE, NA),
     e = as.complex(1:5)
   )
-  expect_message(
-    convert_to_na(d, na = list(3, "c", TRUE, "2022-01-02")),
-    "must be of class 'Date'"
-  )
-  x <- convert_to_na(d, na = list(3, "c", TRUE, as.Date("2022-01-02")))
+  convert_to_na(d, na = list(3, "c", TRUE, "2022-01-02"), verbose = FALSE)
+  x <- convert_to_na(d, na = list(3, "c", TRUE, as.Date("2022-01-02")), verbose = FALSE)
   expect_equal(x, out, ignore_attr = TRUE, tolerance = 1e-3)
 })
 

--- a/tests/testthat/test-data_cut.R
+++ b/tests/testthat/test-data_cut.R
@@ -3,12 +3,12 @@ d <- sample(1:10, size = 500, replace = TRUE)
 
 test_that("recode median", {
   expect_identical(categorize(d), ifelse(d >= median(d), 2, 1))
-  expect_identical(categorize(d, lowest = 0), ifelse(d >= median(d), 1, 0))
+  expect_identical(categorize(d, lowest = 0), as.numeric(d >= median(d)))
 })
 
 test_that("recode mean", {
   expect_identical(categorize(d, split = "mean"), ifelse(d >= mean(d), 2, 1))
-  expect_identical(categorize(d, split = "mean", lowest = 0), ifelse(d >= mean(d), 1, 0))
+  expect_identical(categorize(d, split = "mean", lowest = 0), as.numeric(d >= mean(d)))
 })
 
 test_that("recode quantile", {

--- a/tests/testthat/test-data_cut.R
+++ b/tests/testthat/test-data_cut.R
@@ -33,7 +33,16 @@ test_that("recode range", {
   d2[d > 60 & d <= 80] <- 4
   d2[d > 80] <- 5
   expect_equal(table(categorize(d, split = "equal_range", range = 20)), table(d2), ignore_attr = TRUE)
-  expect_equal(table(categorize(d, split = "equal_range", range = 20, lowest = 1)), table(d2), ignore_attr = TRUE)
+  expect_equal(
+    table(categorize(
+      d,
+      split = "equal_range",
+      range = 20,
+      lowest = 1
+    )),
+    table(d2),
+    ignore_attr = TRUE
+  )
 
   d2 <- d
   d2[d < 20] <- 0
@@ -41,7 +50,16 @@ test_that("recode range", {
   d2[d >= 40 & d < 60] <- 2
   d2[d >= 60 & d < 80] <- 3
   d2[d >= 80] <- 4
-  expect_equal(table(categorize(d, split = "equal_range", range = 20, lowest = 0)), table(d2), ignore_attr = TRUE)
+  expect_equal(
+    table(categorize(
+      d,
+      split = "equal_range",
+      range = 20,
+      lowest = 0
+    )),
+    table(d2),
+    ignore_attr = TRUE
+  )
 })
 
 test_that("recode length", {
@@ -53,7 +71,16 @@ test_that("recode length", {
   d2[d > 60 & d <= 80] <- 4
   d2[d > 80] <- 5
   expect_equal(table(categorize(d, split = "equal_length", n_groups = 5)), table(d2), ignore_attr = TRUE)
-  expect_equal(table(categorize(d, split = "equal_length", n_groups = 5, lowest = 1)), table(d2), ignore_attr = TRUE)
+  expect_equal(
+    table(categorize(
+      d,
+      split = "equal_length",
+      n_groups = 5,
+      lowest = 1
+    )),
+    table(d2),
+    ignore_attr = TRUE
+  )
 })
 
 set.seed(123)
@@ -61,7 +88,15 @@ x <- sample(1:10, size = 30, replace = TRUE)
 test_that("recode factor labels", {
   expect_type(categorize(x, "equal_length", n_groups = 3), "double")
   expect_s3_class(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high")), "factor")
-  expect_identical(levels(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high"))), c("low", "mid", "high"))
+  expect_identical(
+    levels(categorize(
+      x,
+      "equal_length",
+      n_groups = 3,
+      labels = c("low", "mid", "high")
+    )),
+    c("low", "mid", "high")
+  )
   t1 <- table(categorize(x, "equal_length", n_groups = 3))
   t2 <- table(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high")))
   expect_equal(t1, t2, ignore_attr = TRUE)

--- a/tests/testthat/test-data_cut.R
+++ b/tests/testthat/test-data_cut.R
@@ -2,13 +2,13 @@ set.seed(123)
 d <- sample(1:10, size = 500, replace = TRUE)
 
 test_that("recode median", {
-  expect_equal(categorize(d), ifelse(d >= median(d), 2, 1))
-  expect_equal(categorize(d, lowest = 0), ifelse(d >= median(d), 1, 0))
+  expect_identical(categorize(d), ifelse(d >= median(d), 2, 1))
+  expect_identical(categorize(d, lowest = 0), ifelse(d >= median(d), 1, 0))
 })
 
 test_that("recode mean", {
-  expect_equal(categorize(d, split = "mean"), ifelse(d >= mean(d), 2, 1))
-  expect_equal(categorize(d, split = "mean", lowest = 0), ifelse(d >= mean(d), 1, 0))
+  expect_identical(categorize(d, split = "mean"), ifelse(d >= mean(d), 2, 1))
+  expect_identical(categorize(d, split = "mean", lowest = 0), ifelse(d >= mean(d), 1, 0))
 })
 
 test_that("recode quantile", {
@@ -17,8 +17,8 @@ test_that("recode quantile", {
   q <- quantile(d, probs = c(1 / 3, 2 / 3, 1))
   f <- cut(d, breaks = unique(c(min(d), q, max(d))), include.lowest = TRUE, right = FALSE)
   levels(f) <- 1:nlevels(f)
-  expect_equal(categorize(d, split = "quantile", n_groups = 3), as.numeric(f))
-  expect_equal(categorize(d, split = "quantile", n_groups = 3, lowest = 0), as.numeric(f) - 1)
+  expect_identical(categorize(d, split = "quantile", n_groups = 3), as.numeric(f))
+  expect_identical(categorize(d, split = "quantile", n_groups = 3, lowest = 0), as.numeric(f) - 1)
 })
 
 set.seed(123)
@@ -61,7 +61,7 @@ x <- sample(1:10, size = 30, replace = TRUE)
 test_that("recode factor labels", {
   expect_type(categorize(x, "equal_length", n_groups = 3), "double")
   expect_s3_class(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high")), "factor")
-  expect_equal(levels(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high"))), c("low", "mid", "high"))
+  expect_identical(levels(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high"))), c("low", "mid", "high"))
   t1 <- table(categorize(x, "equal_length", n_groups = 3))
   t2 <- table(categorize(x, "equal_length", n_groups = 3, labels = c("low", "mid", "high")))
   expect_equal(t1, t2, ignore_attr = TRUE)
@@ -72,46 +72,46 @@ test_that("recode data frame", {
   x <- iris
   out <- categorize(x, split = "median", select = c("Sepal.Length", "Sepal.Width"))
   expect_s3_class(out, "data.frame")
-  expect_equal(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
-  expect_equal(out$Petal.Length, iris$Petal.Length)
+  expect_identical(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
+  expect_identical(out$Petal.Length, iris$Petal.Length)
 
   out <- categorize(x, split = "median", select = starts_with("Sepal"))
   expect_s3_class(out, "data.frame")
-  expect_equal(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
-  expect_equal(out$Petal.Length, iris$Petal.Length)
+  expect_identical(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
+  expect_identical(out$Petal.Length, iris$Petal.Length)
 
   out <- categorize(x, split = "median", select = ~ Sepal.Width + Sepal.Length)
   expect_s3_class(out, "data.frame")
-  expect_equal(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
-  expect_equal(out$Petal.Length, iris$Petal.Length)
+  expect_identical(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
+  expect_identical(out$Petal.Length, iris$Petal.Length)
 
   out <- categorize(x, split = "median", select = Sepal.Length)
   expect_s3_class(out, "data.frame")
-  expect_equal(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
-  expect_equal(out$Petal.Length, iris$Petal.Length)
+  expect_identical(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
+  expect_identical(out$Petal.Length, iris$Petal.Length)
 
   expect_warning(
     out <- categorize(x, split = "median", select = c("sepal.Length", "sepal.Width"), ignore_case = FALSE),
     "not found"
   )
-  expect_equal(out$Sepal.Length, iris$Sepal.Length)
+  expect_identical(out$Sepal.Length, iris$Sepal.Length)
 
   out <- categorize(x, split = "median", select = starts_with("sepal"), ignore_case = TRUE)
   expect_s3_class(out, "data.frame")
-  expect_equal(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
-  expect_equal(out$Petal.Length, iris$Petal.Length)
+  expect_identical(out$Sepal.Length, ifelse(iris$Sepal.Length >= median(iris$Sepal.Length), 2, 1))
+  expect_identical(out$Petal.Length, iris$Petal.Length)
 
   out <- categorize(x, split = "median", select = starts_with("sepal"), ignore_case = FALSE)
-  expect_equal(out$Sepal.Length, iris$Sepal.Length)
+  expect_identical(out$Sepal.Length, iris$Sepal.Length)
 
   out <- categorize(x, split = "median", select = starts_with("sepal"), ignore_case = TRUE, append = "_r")
-  expect_equal(colnames(out), c(
+  expect_identical(colnames(out), c(
     "Sepal.Length", "Sepal.Width", "Petal.Length",
     "Petal.Width", "Species", "Sepal.Length_r", "Sepal.Width_r"
   ))
 
   out <- categorize(iris, split = "median", select = starts_with("Sepal"))
-  expect_equal(
+  expect_identical(
     out$Sepal.Length,
     c(
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1,
@@ -129,7 +129,7 @@ test_that("recode data frame", {
 
   x <- poorman::group_by(iris, Species)
   out <- categorize(x, split = "median", select = starts_with("Sepal"))
-  expect_equal(
+  expect_identical(
     out$Sepal.Length,
     c(
       2, 1, 1, 1, 2, 2, 1, 2, 1, 1, 2, 1, 1, 1, 2, 2, 2, 2, 2, 2,
@@ -151,20 +151,20 @@ test_that("recode all NA", {
     y <- categorize(x),
     "can't be recoded"
   )
-  expect_equal(y, x)
+  expect_identical(y, x)
 
   x <- rep(NA_real_, 10)
   expect_message(
     y <- categorize(x),
     "only missing values"
   )
-  expect_equal(y, x)
+  expect_identical(y, x)
 })
 
 
 
 test_that("recode numeric", {
-  expect_equal(
+  expect_identical(
     categorize(mtcars$hp, split = c(100, 150)),
     c(
       2, 2, 1, 2, 3, 2, 3, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3, 1, 1, 1,
@@ -175,10 +175,10 @@ test_that("recode numeric", {
   x[mtcars$hp < 100] <- 1
   x[mtcars$hp >= 100 & mtcars$hp < 150] <- 2
   x[mtcars$hp >= 150] <- 3
-  expect_equal(categorize(mtcars$hp, split = c(100, 150)), x)
-  expect_equal(categorize(mtcars$hp, split = c(100, 150), lowest = NULL), x)
+  expect_identical(categorize(mtcars$hp, split = c(100, 150)), x)
+  expect_identical(categorize(mtcars$hp, split = c(100, 150), lowest = NULL), x)
 
-  expect_equal(
+  expect_identical(
     categorize(mtcars$hp, split = "equal_range", range = 50, lowest = NULL),
     c(
       2, 2, 1, 2, 3, 2, 4, 1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 1, 1, 1,
@@ -189,7 +189,7 @@ test_that("recode numeric", {
 
 # select helpers ------------------------------
 test_that("categorize regex", {
-  expect_equal(
+  expect_identical(
     categorize(mtcars, select = "pg", regex = TRUE),
     categorize(mtcars, select = "mpg")
   )

--- a/tests/testthat/test-data_cut.R
+++ b/tests/testthat/test-data_cut.R
@@ -147,10 +147,18 @@ test_that("recode data frame", {
 
 test_that("recode all NA", {
   x <- rep(NA, 10)
-  expect_equal(categorize(x), x)
+  expect_message(
+    y <- categorize(x),
+    "can't be recoded"
+  )
+  expect_equal(y, x)
 
-  x <- as.numeric(rep(NA, 10))
-  expect_warning(expect_equal(categorize(x), x))
+  x <- rep(NA_real_, 10)
+  expect_message(
+    y <- categorize(x),
+    "only missing values"
+  )
+  expect_equal(y, x)
 })
 
 

--- a/tests/testthat/test-data_merge.R
+++ b/tests/testthat/test-data_merge.R
@@ -175,7 +175,7 @@ test_that("bind-join", {
 
   expect_identical(
     suppressWarnings(data_merge(x2, y2, join = "full")),
-    poorman::full_join(x2, y2),
+    suppressMessages(poorman::full_join(x2, y2)),
     ignore_attr = TRUE
   )
 
@@ -269,3 +269,4 @@ test_that("join when all 'by' are not present", {
     regexp = "Not all columns"
   )
 })
+

--- a/tests/testthat/test-data_merge.R
+++ b/tests/testthat/test-data_merge.R
@@ -14,19 +14,19 @@ test_that("left-join", {
 
   out <- data_merge(x, y, join = "left")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(3, 6))
+  expect_identical(dim(out), c(3L, 6L))
   expect_identical(out, suppressMessages(poorman::left_join(x, y)))
 
   out <- data_merge(x, y, join = "left", by = "id")
   expect_identical(colnames(out), c("cyl", "disp", "id", "hp", "drat", "mpg.x", "mpg.y"))
   expect_identical(out$disp, poorman::left_join(x, y, by = "id")$disp)
-  expect_equal(dim(out), c(3, 7))
+  expect_identical(dim(out), c(3L, 7L))
 
   out <- data_merge(x, y, join = "left", by = "mpg")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "hp", "drat", "id.x", "id.y"))
   expect_identical(out$disp, poorman::left_join(x, y, by = "mpg")$disp)
   expect_identical(out$mpg, poorman::left_join(x, y, by = "mpg")$mpg)
-  expect_equal(dim(out), c(3, 7))
+  expect_identical(dim(out), c(3L, 7L))
 })
 
 
@@ -46,11 +46,11 @@ test_that("right-join", {
 
   out <- data_merge(x, y, join = "right")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(3, 6))
+  expect_identical(dim(out), c(3L, 6L))
   # in data_merge(), we keep sorting from x, so do some preparation here
   poor_out <- suppressMessages(poorman::right_join(x, y))
   poor_out <- poor_out[order(poor_out$id), ]
-  row.names(poor_out) <- 1:nrow(poor_out)
+  row.names(poor_out) <- seq_len(nrow(poor_out))
   expect_identical(out, poor_out)
 
   out <- data_merge(x, y, join = "right", by = "id")
@@ -59,7 +59,7 @@ test_that("right-join", {
   poor_out <- suppressMessages(poorman::right_join(x, y, by = "id"))
   poor_out <- poor_out[order(poor_out$id), ]
   expect_identical(out$disp, poor_out$disp)
-  expect_equal(dim(out), c(3, 7))
+  expect_identical(dim(out), c(3L, 7L))
 
   out <- data_merge(x, y, join = "right", by = "mpg")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "hp", "drat", "id.x", "id.y"))
@@ -69,7 +69,7 @@ test_that("right-join", {
   out <- out[order(out$id.y, decreasing = TRUE), ]
   expect_identical(out$disp, poor_out$disp)
   expect_identical(out$mpg, poor_out$mpg)
-  expect_equal(dim(out), c(3, 7))
+  expect_identical(dim(out), c(3L, 7L))
 })
 
 
@@ -80,17 +80,17 @@ test_that("inner-join", {
 
   out <- data_merge(x, y, join = "inner")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(0, 6))
+  expect_identical(dim(out), c(0L, 6L))
 
   out <- data_merge(x, y, join = "inner", by = "id")
   expect_identical(colnames(out), c("cyl", "disp", "id", "hp", "drat", "mpg.x", "mpg.y"))
   expect_identical(out$disp, poorman::inner_join(x, y, by = "id")$disp)
-  expect_equal(dim(out), c(2, 7))
+  expect_identical(dim(out), c(2L, 7L))
 
   out <- data_merge(x, y, join = "inner", by = "mpg")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "hp", "drat", "id.x", "id.y"))
   expect_identical(out$disp, poorman::inner_join(x, y, by = "mpg")$disp)
-  expect_equal(dim(out), c(1, 7))
+  expect_identical(dim(out), c(1L, 7L))
 })
 
 
@@ -99,25 +99,25 @@ test_that("inner-join", {
 test_that("full-join", {
   out <- data_merge(x, y, join = "full")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(6, 6))
+  expect_identical(dim(out), c(6L, 6L))
   expect_identical(out$mpg, c(22.8, 21.4, 18.7, 19.7, 15, 21.4), tolerance = 1e-2)
   expect_identical(out$id, c(1, 2, 3, 2, 3, 4), tolerance = 1e-2)
 
   out <- data_merge(x, y, join = "full", by = "id")
   expect_identical(colnames(out), c("cyl", "disp", "id", "hp", "drat", "mpg.x", "mpg.y"))
-  expect_equal(dim(out), c(4, 7))
+  expect_identical(dim(out), c(4L, 7L))
   expect_identical(out$mpg.x, c(22.8, 21.4, 18.7, NA), tolerance = 1e-2)
   expect_identical(out$id, 1:4, tolerance = 1e-2)
 
   out <- data_merge(x, y, join = "full", by = "mpg")
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "hp", "drat", "id.x", "id.y"))
-  expect_equal(dim(out), c(5, 7))
+  expect_identical(dim(out), c(5L, 7L))
   expect_identical(out$mpg, c(22.8, 21.4, 18.7, 19.7, 15), tolerance = 1e-2)
   expect_identical(out$id.x, c(1, 2, 3, NA, NA), tolerance = 1e-2)
 
   out <- data_merge(x, y, join = "full", by = c("id", "mpg"))
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(6, 6))
+  expect_identical(dim(out), c(6L, 6L))
   expect_identical(out$mpg, c(22.8, 21.4, 18.7, 19.7, 15, 21.4), tolerance = 1e-2)
   expect_identical(out$id, c(1, 2, 3, 2, 3, 4), tolerance = 1e-2)
 })
@@ -130,9 +130,9 @@ test_that("bind-join", {
 
   out <- data_merge(x, y, join = "bind")
   poor_out <- poorman::bind_rows(x, y)
-  row.names(poor_out) <- 1:nrow(poor_out)
+  row.names(poor_out) <- seq_len(nrow(poor_out))
   expect_identical(colnames(out), c("mpg", "cyl", "disp", "id", "hp", "drat"))
-  expect_equal(dim(out), c(6, 6))
+  expect_identical(dim(out), c(6L, 6L))
   expect_identical(out, poor_out)
 
   # by will be ignored
@@ -153,8 +153,8 @@ test_that("bind-join", {
     out <- data_merge(x, y, join = "bind", id = "mpg"),
     regexp = "already exists"
   )
-  expect_identical(
-    names(out),
+  expect_named(
+    out,
     c(names(mtcars), "mpg_1")
   )
   expect_identical(out$mpg_1, c(1, 2))
@@ -236,8 +236,8 @@ test_that("join data frames in a list", {
     out <- data_merge(list(x, y), join = "bind", id = "mpg"),
     regexp = "already exists"
   )
-  expect_identical(
-    names(out),
+  expect_named(
+    out,
     c(names(mtcars), "mpg_1")
   )
   expect_identical(out$mpg_1, c(1, 2))
@@ -246,16 +246,16 @@ test_that("join data frames in a list", {
 
 # join empty data frames -----------------------
 
-x <- data.frame("x" = character())
-y <- data.frame("x" = character())
-z <- data.frame("y" = character())
+x <- data.frame("x" = character(), stringsAsFactors = FALSE)
+y <- data.frame("x" = character(), stringsAsFactors = FALSE)
+z <- data.frame("y" = character(), stringsAsFactors = FALSE)
 
 test_that("join empty data frames", {
-  expect_equal(dim(data_merge(x, y, join = "left")), c(0, 1))
-  expect_equal(dim(data_merge(x, y, join = "full")), c(0, 1))
-  expect_equal(dim(data_merge(x, y, join = "right")), c(0, 1))
-  expect_equal(dim(data_merge(x, y, join = "bind")), c(0, 1))
-  expect_equal(dim(data_merge(x, z, join = "bind")), c(0, 2))
+  expect_identical(dim(data_merge(x, y, join = "left")), c(0L, 1L))
+  expect_identical(dim(data_merge(x, y, join = "full")), c(0L, 1L))
+  expect_identical(dim(data_merge(x, y, join = "right")), c(0L, 1L))
+  expect_identical(dim(data_merge(x, y, join = "bind")), c(0L, 1L))
+  expect_identical(dim(data_merge(x, z, join = "bind")), c(0L, 2L))
 })
 
 # join when all "by" are not present ---------------------

--- a/tests/testthat/test-data_merge.R
+++ b/tests/testthat/test-data_merge.R
@@ -269,4 +269,3 @@ test_that("join when all 'by' are not present", {
     regexp = "Not all columns"
   )
 })
-

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -12,7 +12,10 @@ skip_if_not_installed("rio")
 # csv -------------------------
 
 test_that("data_read", {
-  d <- data_read("https://raw.githubusercontent.com/easystats/circus/master/data/bootstrapped.csv")
+  d <- data_read(
+    "https://raw.githubusercontent.com/easystats/circus/master/data/bootstrapped.csv",
+    verbose = FALSE
+  )
   expect_equal(dim(d), c(10000, 4))
 })
 
@@ -21,7 +24,10 @@ test_that("data_read", {
 # csv -------------------------
 
 test_that("data_read, skip_empty", {
-  d <- data_read("https://raw.githubusercontent.com/easystats/circus/master/data/test_skip_empty.csv")
+  d <- data_read(
+    "https://raw.githubusercontent.com/easystats/circus/master/data/test_skip_empty.csv",
+    verbose = FALSE
+  )
   expect_equal(ncol(d), 3)
   expect_equal(colnames(d), c("Var1", "Var2", "Var3"))
 })
@@ -36,7 +42,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_equal(nrow(d), 3)
   expect_equal(colnames(d), c("a", "b", "c"))
   expect_equal(sum(sapply(d, is.numeric)), 2)
@@ -55,7 +64,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_equal(nrow(d), 3)
   expect_equal(colnames(d), c("a", "b", "c"))
   expect_equal(sum(sapply(d, is.numeric)), 2)
@@ -74,7 +86,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_identical(
     d,
     data.frame(
@@ -97,7 +112,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_identical(
     d,
     data.frame(
@@ -120,7 +138,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_equal(sum(sapply(d, is.factor)), 15)
   expect_equal(sum(sapply(d, is.numeric)), 11)
   expect_equal(
@@ -154,7 +175,10 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_equal(
     d,
     structure(
@@ -192,13 +216,19 @@ httr::stop_for_status(request)
 writeBin(httr::content(request, type = "raw"), temp_file)
 
 test_that("data_read", {
-  d <- data_read(temp_file)
+  d <- data_read(
+    temp_file,
+    verbose = FALSE
+  )
   expect_equal(sum(sapply(d, is.factor)), 15)
   expect_equal(sum(sapply(d, is.numeric)), 11)
 })
 
 test_that("data_read, convert_factors", {
-  d <- data_read(temp_file, convert_factors = FALSE)
+  d <- data_read(
+    temp_file, convert_factors = FALSE,
+    verbose = FALSE
+  )
   expect_equal(sum(sapply(d, is.factor)), 0)
   expect_equal(sum(sapply(d, is.numeric)), 26)
 })

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -16,7 +16,7 @@ test_that("data_read", {
     "https://raw.githubusercontent.com/easystats/circus/master/data/bootstrapped.csv",
     verbose = FALSE
   )
-  expect_equal(dim(d), c(10000, 4))
+  expect_identical(dim(d), c(10000L, 4L))
 })
 
 
@@ -28,8 +28,8 @@ test_that("data_read, skip_empty", {
     "https://raw.githubusercontent.com/easystats/circus/master/data/test_skip_empty.csv",
     verbose = FALSE
   )
-  expect_equal(ncol(d), 3)
-  expect_equal(colnames(d), c("Var1", "Var2", "Var3"))
+  expect_identical(ncol(d), 3L)
+  expect_identical(colnames(d), c("Var1", "Var2", "Var3"))
 })
 
 
@@ -46,10 +46,10 @@ test_that("data_read", {
     temp_file,
     verbose = FALSE
   )
-  expect_equal(nrow(d), 3)
-  expect_equal(colnames(d), c("a", "b", "c"))
-  expect_equal(sum(sapply(d, is.numeric)), 2)
-  expect_equal(sum(sapply(d, is.character)), 1)
+  expect_identical(nrow(d), 3L)
+  expect_identical(colnames(d), c("a", "b", "c"))
+  expect_identical(sum(vapply(d, is.numeric, FUN.VALUE = logical(1L))), 2L)
+  expect_identical(sum(vapply(d, is.character, FUN.VALUE = logical(1L))), 1L)
 })
 
 unlink(temp_file)
@@ -68,10 +68,10 @@ test_that("data_read", {
     temp_file,
     verbose = FALSE
   )
-  expect_equal(nrow(d), 3)
-  expect_equal(colnames(d), c("a", "b", "c"))
-  expect_equal(sum(sapply(d, is.numeric)), 2)
-  expect_equal(sum(sapply(d, is.character)), 1)
+  expect_identical(nrow(d), 3L)
+  expect_identical(colnames(d), c("a", "b", "c"))
+  expect_identical(sum(vapply(d, is.numeric, FUN.VALUE = logical(1L))), 2L)
+  expect_identical(sum(vapply(d, is.character, FUN.VALUE = logical(1L))), 1L)
 })
 
 unlink(temp_file)
@@ -142,9 +142,9 @@ test_that("data_read", {
     temp_file,
     verbose = FALSE
   )
-  expect_equal(sum(sapply(d, is.factor)), 15)
-  expect_equal(sum(sapply(d, is.numeric)), 11)
-  expect_equal(
+  expect_identical(sum(vapply(d, is.factor, FUN.VALUE = logical(1L))), 15L)
+  expect_identical(sum(vapply(d, is.numeric, FUN.VALUE = logical(1L))), 11L)
+  expect_identical(
     levels(d$c172code),
     c(
       "low level of education",
@@ -152,7 +152,7 @@ test_that("data_read", {
       "high level of education"
     )
   )
-  expect_equal(
+  expect_identical(
     attr(d$n4pstu, "labels"),
     c(
       `spouse/partner` = 1,
@@ -179,7 +179,7 @@ test_that("data_read", {
     temp_file,
     verbose = FALSE
   )
-  expect_equal(
+  expect_identical(
     d,
     structure(
       list(
@@ -220,8 +220,8 @@ test_that("data_read", {
     temp_file,
     verbose = FALSE
   )
-  expect_equal(sum(sapply(d, is.factor)), 15)
-  expect_equal(sum(sapply(d, is.numeric)), 11)
+  expect_identical(sum(vapply(d, is.factor, FUN.VALUE = logical(1L))), 15L)
+  expect_identical(sum(vapply(d, is.numeric, FUN.VALUE = logical(1L))), 11L)
 })
 
 test_that("data_read, convert_factors", {
@@ -230,8 +230,8 @@ test_that("data_read, convert_factors", {
     convert_factors = FALSE,
     verbose = FALSE
   )
-  expect_equal(sum(sapply(d, is.factor)), 0)
-  expect_equal(sum(sapply(d, is.numeric)), 26)
+  expect_identical(sum(vapply(d, is.factor, FUN.VALUE = logical(1L))), 0L)
+  expect_identical(sum(vapply(d, is.numeric, FUN.VALUE = logical(1L))), 26L)
 })
 
 unlink(temp_file)

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -226,7 +226,8 @@ test_that("data_read", {
 
 test_that("data_read, convert_factors", {
   d <- data_read(
-    temp_file, convert_factors = FALSE,
+    temp_file,
+    convert_factors = FALSE,
     verbose = FALSE
   )
   expect_equal(sum(sapply(d, is.factor)), 0)

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -3,22 +3,22 @@ test <- head(iris)
 # basic tests --------------
 
 test_that("data_rename works with one or several replacements", {
-  expect_equal(
-    names(data_rename(test, "Sepal.Length", "length")),
+  expect_named(
+    data_rename(test, "Sepal.Length", "length"),
     c("length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
   )
-  expect_equal(
-    names(data_rename(
+  expect_named(
+    data_rename(
       test, c("Sepal.Length", "Sepal.Width"),
       c("length", "width")
-    )),
+    ),
     c("length", "width", "Petal.Length", "Petal.Width", "Species")
   )
 })
 
 test_that("data_rename returns a data frame", {
   x <- data_rename(test, "Sepal.Length", "length")
-  expect_true(class(x) == "data.frame")
+  expect_s3_class(x, "data.frame")
 })
 
 test_that("data_rename: pattern must be of type character", {
@@ -36,8 +36,8 @@ test_that("data_rename: pattern must be of type character", {
 
 test_that("data_rename uses indices when no replacement", {
   x <- data_rename(test, pattern = c("Sepal.Length", "Petal.Length"))
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x), c("1", "Sepal.Width", "2", "Petal.Width", "Species"))
+  expect_identical(dim(test), dim(x))
+  expect_named(x, c("1", "Sepal.Width", "2", "Petal.Width", "Species"))
 })
 
 test_that("data_rename works when too many names in 'replacement'", {
@@ -45,8 +45,8 @@ test_that("data_rename works when too many names in 'replacement'", {
     x <- data_rename(test, replacement = paste0("foo", 1:6)),
     "There are more names in"
   )
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x), paste0("foo", 1:5))
+  expect_identical(dim(test), dim(x))
+  expect_named(x, paste0("foo", 1:5))
 })
 
 test_that("data_rename works when not enough names in 'replacement'", {
@@ -54,8 +54,8 @@ test_that("data_rename works when not enough names in 'replacement'", {
     x <- data_rename(test, replacement = paste0("foo", 1:2)),
     "There are more names in"
   )
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x), c("foo1", "foo2", "Petal.Length", "Petal.Width", "Species"))
+  expect_identical(dim(test), dim(x))
+  expect_named(x, c("foo1", "foo2", "Petal.Length", "Petal.Width", "Species"))
 })
 
 
@@ -64,12 +64,12 @@ test_that("data_rename works when not enough names in 'replacement'", {
 test_that("data_rename uses the whole dataset when pattern = NULL", {
   x1 <- data_rename(test)
   x2 <- data_rename(test, pattern = names(test))
-  expect_equal(dim(test), dim(x1))
+  expect_identical(dim(test), dim(x1))
   expect_identical(x1, x2)
 
   x3 <- data_rename(test, replacement = paste0("foo", 1:5))
   x4 <- data_rename(test, pattern = names(test), replacement = paste0("foo", 1:5))
-  expect_equal(dim(test), dim(x3))
+  expect_identical(dim(test), dim(x3))
   expect_identical(x3, x4)
 })
 
@@ -92,13 +92,13 @@ test_that("data_rename deals correctly with duplicated replacement", {
     pattern = names(test)[1:4],
     replacement = c("foo", "bar", "foo", "bar")
   )
-  expect_equal(dim(test), dim(x))
-  expect_equal(names(x)[1:4], c("foo", "bar", "foo.2", "bar.2"))
+  expect_identical(dim(test), dim(x))
+  expect_named(x[1:4], c("foo", "bar", "foo.2", "bar.2"))
 })
 
 test_that("data_rename doesn't change colname if invalid pattern", {
   x <- suppressMessages(data_rename(test, "FakeCol", "length"))
-  expect_equal(
+  expect_identical(
     names(x),
     names(test)
   )
@@ -118,5 +118,5 @@ test_that("data_rename preserves attributes", {
   out2 <- data_rename(out, "p", "p-val")
   a2 <- attributes(out2)
 
-  expect_equal(names(a1), names(a2))
+  expect_identical(names(a1), names(a2))
 })

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -98,10 +98,7 @@ test_that("data_rename deals correctly with duplicated replacement", {
 
 test_that("data_rename doesn't change colname if invalid pattern", {
   x <- suppressMessages(data_rename(test, "FakeCol", "length"))
-  expect_identical(
-    names(x),
-    names(test)
-  )
+  expect_named(x, names(test))
 })
 
 
@@ -118,5 +115,5 @@ test_that("data_rename preserves attributes", {
   out2 <- data_rename(out, "p", "p-val")
   a2 <- attributes(out2)
 
-  expect_identical(names(a1), names(a2))
+  expect_named(a1, names(a2))
 })

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -97,8 +97,9 @@ test_that("data_rename deals correctly with duplicated replacement", {
 })
 
 test_that("data_rename doesn't change colname if invalid pattern", {
+  x <- suppressMessages(data_rename(test, "FakeCol", "length"))
   expect_equal(
-    names(data_rename(test, "FakeCol", "length")),
+    names(x),
     names(test)
   )
 })

--- a/tests/testthat/test-data_reverse.R
+++ b/tests/testthat/test-data_reverse.R
@@ -338,7 +338,8 @@ value2 <- sample(1:10, 6, replace = TRUE)
 test_df <- data.frame(
   id = rep(c("A", "B"), each = 3),
   value1 = value1,
-  value2 = value2
+  value2 = value2,
+  stringsAsFactors = FALSE
 )
 
 test_that("reverse works with data frames (grouped data)", {
@@ -353,7 +354,8 @@ test_that("reverse works with data frames (grouped data)", {
     data.frame(
       id = rep(c("A", "B"), each = 3),
       value1 = c(10, 10, 3, 6, 2, 3),
-      value2 = c(4, 6, 3, 10, 6, 5)
+      value2 = c(4, 6, 3, 10, 6, 5),
+      stringsAsFactors = FALSE
     )
   )
 })
@@ -367,7 +369,8 @@ value2 <- sample(c(1:10, NA), 6, replace = TRUE)
 test_df <- data.frame(
   id = rep(c("A", "B"), each = 3),
   value1 = value1,
-  value2 = value2
+  value2 = value2,
+  stringsAsFactors = FALSE
 )
 
 test_that("reverse works with data frames containing NAs (grouped data)", {
@@ -382,7 +385,8 @@ test_that("reverse works with data frames containing NAs (grouped data)", {
     data.frame(
       id = rep(c("A", "B"), each = 3),
       value1 = c(10, 4, 4, 5, 3, 4),
-      value2 = c(NA, 10, 9, 7, 6, 8)
+      value2 = c(NA, 10, 9, 7, 6, 8),
+      stringsAsFactors = FALSE
     )
   )
 })

--- a/tests/testthat/test-data_reverse.R
+++ b/tests/testthat/test-data_reverse.R
@@ -2,22 +2,22 @@
 # https://github.com/easystats/datawizard/issues/106#issuecomment-1066628399
 
 test_that("reverse works with numeric", {
-  expect_equal(
+  expect_identical(
     reverse(1:5),
-    5:1
+    as.double(5:1)
   )
-  expect_equal(
+  expect_identical(
     reverse(-2:2),
-    2:-2
+    as.double(2:-2)
   )
 })
 
 test_that("reverse works with factor", {
-  expect_equal(
+  expect_identical(
     reverse(factor(1:5)),
     factor(5:1)
   )
-  expect_equal(
+  expect_identical(
     reverse(factor(-2:2)),
     factor(2:-2)
   )
@@ -28,24 +28,24 @@ test_that("reverse works with data frame", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse(test, select = "x"),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse(test, exclude = "x"),
     data.frame(
       x = 1:5,
       y = c(6, 1, 7, 4, 8)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse(test),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(6, 1, 7, 4, 8)
     )
   )
@@ -56,17 +56,17 @@ test_that("reverse: arg 'select' works with formula", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse(test, select = ~x),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse(test, select = ~ x + y),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(6, 1, 7, 4, 8)
     )
   )
@@ -77,25 +77,25 @@ test_that("reverse: arg 'exclude' works with formula", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse(test, exclude = ~x),
     data.frame(
       x = 1:5,
       y = c(6, 1, 7, 4, 8)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse(test, exclude = ~ x + y),
     test
   )
 })
 
 test_that("reverse: argument 'range' works", {
-  expect_equal(
+  expect_identical(
     reverse(c(1, 3, 4), range = c(0, 4)),
     c(3, 1, 0)
   )
-  expect_equal(
+  expect_identical(
     reverse(factor(c(1, 2, 3, 4, 5)), range = 0:10),
     factor(9:5, levels = 0:10)
   )
@@ -104,35 +104,35 @@ test_that("reverse: argument 'range' works", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse(test, select = "x", range = c(0, 8)),
     data.frame(
-      x = 7:3,
+      x = as.double(7:3),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse(test, range = c(0, 8)),
     data.frame(
-      x = 7:3,
+      x = as.double(7:3),
       y = c(5, 0, 6, 3, 7)
     )
   )
 })
 
 test_that("reverse ignores NA", {
-  expect_equal(
+  expect_identical(
     reverse(c(1, 2, 8, NA)),
     c(8, 7, 1, NA)
   )
 })
 
 test_that("reverse returns NA if only NA provided", {
-  expect_equal(
+  expect_identical(
     reverse(c(NA_real_, NA_real_)),
     c(NA_real_, NA_real_)
   )
-  expect_equal(
+  expect_identical(
     reverse(factor(c(NA, NA))),
     factor(c(NA, NA))
   )
@@ -160,22 +160,22 @@ test_that("reverse msg for unsupported", {
 # Same tests with reverse_scale (alias) --------------------------
 
 test_that("reverse_scale works with numeric", {
-  expect_equal(
+  expect_identical(
     reverse_scale(1:5),
-    5:1
+    as.double(5:1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(-2:2),
-    2:-2
+    as.double(2:-2)
   )
 })
 
 test_that("reverse_scale works with factor", {
-  expect_equal(
+  expect_identical(
     reverse_scale(factor(1:5)),
     factor(5:1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(factor(-2:2)),
     factor(2:-2)
   )
@@ -186,24 +186,24 @@ test_that("reverse_scale works with data frame", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, select = "x"),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, exclude = "x"),
     data.frame(
       x = 1:5,
       y = c(6, 1, 7, 4, 8)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(6, 1, 7, 4, 8)
     )
   )
@@ -214,17 +214,17 @@ test_that("reverse_scale: arg 'select' works with formula", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, select = ~x),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, select = ~ x + y),
     data.frame(
-      x = 5:1,
+      x = as.double(5:1),
       y = c(6, 1, 7, 4, 8)
     )
   )
@@ -235,25 +235,25 @@ test_that("reverse_scale: arg 'exclude' works with formula", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, exclude = ~x),
     data.frame(
       x = 1:5,
       y = c(6, 1, 7, 4, 8)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, exclude = ~ x + y),
     test
   )
 })
 
 test_that("reverse_scale: argument 'range' works", {
-  expect_equal(
+  expect_identical(
     reverse_scale(c(1, 3, 4), range = c(0, 4)),
     c(3, 1, 0)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(factor(c(1, 2, 3, 4, 5)), range = 0:10),
     factor(9:5, levels = 0:10)
   )
@@ -262,35 +262,35 @@ test_that("reverse_scale: argument 'range' works", {
     x = 1:5,
     y = c(3, 8, 2, 5, 1)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, select = "x", range = c(0, 8)),
     data.frame(
-      x = 7:3,
+      x = as.double(7:3),
       y = c(3, 8, 2, 5, 1)
     )
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(test, range = c(0, 8)),
     data.frame(
-      x = 7:3,
+      x = as.double(7:3),
       y = c(5, 0, 6, 3, 7)
     )
   )
 })
 
 test_that("reverse_scale ignores NA", {
-  expect_equal(
+  expect_identical(
     reverse_scale(c(1, 2, 8, NA)),
     c(8, 7, 1, NA)
   )
 })
 
 test_that("reverse_scale returns NA if only NA provided", {
-  expect_equal(
+  expect_identical(
     reverse_scale(c(NA_real_, NA_real_)),
     c(NA_real_, NA_real_)
   )
-  expect_equal(
+  expect_identical(
     reverse_scale(factor(c(NA, NA))),
     factor(c(NA, NA))
   )
@@ -315,14 +315,14 @@ test_that("reverse_scale select helpers", {
     "Petal.Length" = c(-1, 0)
   ), select = ends_with("length"))
 
-  expect_equal(out$Sepal.Length, iris$Sepal.Length, tolerance = 1e-3)
+  expect_identical(out$Sepal.Length, iris$Sepal.Length, tolerance = 1e-3)
 
   out <- rescale(iris, to = list(
     "Sepal.Length" = c(0, 1),
     "Petal.Length" = c(-1, 0)
   ), select = ends_with("length"), ignore_case = TRUE)
 
-  expect_equal(head(out$Sepal.Length), c(0.22222, 0.16667, 0.11111, 0.08333, 0.19444, 0.30556), tolerance = 1e-3)
+  expect_identical(head(out$Sepal.Length), c(0.22222, 0.16667, 0.11111, 0.08333, 0.19444, 0.30556), tolerance = 1e-3)
 })
 
 
@@ -346,7 +346,7 @@ test_that("reverse works with data frames (grouped data)", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     test_df %>%
       group_by(id) %>%
       reverse(exclude = "id") %>%
@@ -377,7 +377,7 @@ test_that("reverse works with data frames containing NAs (grouped data)", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     test_df %>%
       group_by(id) %>%
       reverse(exclude = "id") %>%
@@ -393,7 +393,7 @@ test_that("reverse works with data frames containing NAs (grouped data)", {
 
 # select helpers ------------------------------
 test_that("reverse regex", {
-  expect_equal(
+  expect_identical(
     reverse(mtcars, select = "arb", regex = TRUE),
     reverse(mtcars, select = "carb")
   )

--- a/tests/testthat/test-data_reverse.R
+++ b/tests/testthat/test-data_reverse.R
@@ -343,7 +343,7 @@ test_df <- data.frame(
 
 test_that("reverse works with data frames (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     test_df %>%
@@ -372,7 +372,7 @@ test_df <- data.frame(
 
 test_that("reverse works with data frames containing NAs (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     test_df %>%

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -267,7 +267,7 @@ test_that("data_to_long: error if no columns to reshape", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 1", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- relig_income %>%
     tidyr::pivot_longer(!religion, names_to = "income", values_to = "count")
@@ -281,7 +281,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 1", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 2", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- billboard %>%
     tidyr::pivot_longer(
@@ -303,7 +303,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 2", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 3", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- billboard %>%
     tidyr::pivot_longer(
@@ -327,7 +327,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 3", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 4", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- billboard %>%
     tidyr::pivot_longer(
@@ -353,7 +353,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 4", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 5", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   suppressWarnings({
     x <- who %>%
@@ -378,7 +378,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 5", {
 
 test_that("data_to_long equivalent to pivot_longer: ex 6", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- who %>%
     tidyr::pivot_longer(
@@ -406,7 +406,7 @@ test_that("data_to_long equivalent to pivot_longer: ex 6", {
 
 test_that("can reshape all cols to long", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(x = 1:2, y = 3:4)
   pv <- data_to_long(df, x:y)
@@ -418,7 +418,7 @@ test_that("can reshape all cols to long", {
 
 test_that("values interleaved correctly", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(
     x = c(1, 2),
@@ -432,7 +432,7 @@ test_that("values interleaved correctly", {
 
 test_that("preserves original keys", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(x = 1:2, y = 2, z = 1:2)
   pv <- data_to_long(df, y:z)
@@ -443,7 +443,7 @@ test_that("preserves original keys", {
 
 test_that("can drop missing values", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- data.frame(x = c(1, NA), y = c(NA, 2))
   pv <- data_to_long(df, x:y, values_drop_na = TRUE)
@@ -454,7 +454,7 @@ test_that("can drop missing values", {
 
 test_that("mixed columns are automatically coerced", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- data.frame(x = factor("a"), y = factor("b"))
   pv <- data_to_long(df, x:y)
@@ -464,7 +464,7 @@ test_that("mixed columns are automatically coerced", {
 
 test_that("error when overwriting existing column", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(x = 1, y = 2)
 
@@ -476,7 +476,7 @@ test_that("error when overwriting existing column", {
 
 test_that("preserve date format", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   family <- tidyr::tibble(
     family = 1:3,

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -82,10 +82,10 @@ test_that("data_to_long works - complex dataset", {
     rows_to = "Participant"
   )
 
-  expect_equal(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5"))
-  expect_equal(unique(long1$Score), c(2L, 4L, 3L, 5L, 6L, 1L, NA))
-  expect_equal(ncol(long1), 26)
-  expect_equal(nrow(long1), 14000)
+  expect_identical(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5"))
+  expect_identical(unique(long1$Score), c(2L, 4L, 3L, 5L, 6L, 1L, NA))
+  expect_identical(ncol(long1), 26L)
+  expect_identical(nrow(long1), 14000L)
 
 
   long1 <- data_to_long(data,
@@ -95,8 +95,8 @@ test_that("data_to_long works - complex dataset", {
     rows_to = "Participant"
   )
 
-  expect_equal(ncol(long1), 30)
-  expect_equal(nrow(long1), nrow(data))
+  expect_identical(ncol(long1), 30L)
+  expect_identical(nrow(long1), nrow(data))
 
   long1 <- data_to_long(data,
     select = starts_with("a"),
@@ -106,9 +106,9 @@ test_that("data_to_long works - complex dataset", {
     ignore_case = TRUE
   )
 
-  expect_equal(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5", "age"))
-  expect_equal(ncol(long1), 25)
-  expect_equal(nrow(long1), 16800)
+  expect_identical(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5", "age"))
+  expect_identical(ncol(long1), 25L)
+  expect_identical(nrow(long1), 16800L)
 
   long1 <- data_to_long(data,
     select = c(1:5, 28),
@@ -118,9 +118,9 @@ test_that("data_to_long works - complex dataset", {
     ignore_case = TRUE
   )
 
-  expect_equal(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5", "age"))
-  expect_equal(ncol(long1), 25)
-  expect_equal(nrow(long1), 16800)
+  expect_identical(unique(long1$Item), c("A1", "A2", "A3", "A4", "A5", "age"))
+  expect_identical(ncol(long1), 25L)
+  expect_identical(nrow(long1), 16800L)
 })
 
 
@@ -196,21 +196,21 @@ d <- data.frame(
 
 test_that("data_to_long works as expected - simple dataset", {
   out <- data_to_long(d, starts_with("score"))
-  expect_equal(
+  expect_identical(
     out$name,
     c("score_t1", "score_t2", "score_t1", "score_t2", "score_t1", "score_t2")
   )
-  expect_equal(
+  expect_identical(
     out$value,
     c(d$score_t1, d$score_t2)[c(1, 4, 2, 5, 3, 6)]
   )
 
   out <- data_to_long(d, contains("t2"), names_to = "NewCol", values_to = "Time")
-  expect_equal(
+  expect_identical(
     out$NewCol,
     c("score_t2", "speed_t2", "score_t2", "speed_t2", "score_t2", "speed_t2")
   )
-  expect_equal(out$Time, c(33, 3, 34, 4, 37, 5))
+  expect_identical(out$Time, c(33, 3, 34, 4, 37, 5))
 })
 
 
@@ -219,11 +219,11 @@ test_that("data_to_long works as expected - select-helper inside functions, usin
     data_to_long(data, select = i, regex = TRUE)
   }
   out <- test_fun(d, "^score")
-  expect_equal(
+  expect_identical(
     out$name,
     c("score_t1", "score_t2", "score_t1", "score_t2", "score_t1", "score_t2")
   )
-  expect_equal(
+  expect_identical(
     out$value,
     c(d$score_t1, d$score_t2)[c(1, 4, 2, 5, 3, 6)]
   )
@@ -412,8 +412,8 @@ test_that("can reshape all cols to long", {
   pv <- data_to_long(df, x:y)
 
   expect_named(pv, c("name", "value"))
-  expect_equal(pv$name, rep(names(df), 2))
-  expect_equal(pv$value, c(1, 3, 2, 4))
+  expect_identical(pv$name, rep(names(df), 2))
+  expect_identical(pv$value, c(1L, 3L, 2L, 4L))
 })
 
 test_that("values interleaved correctly", {
@@ -423,11 +423,11 @@ test_that("values interleaved correctly", {
   df <- tibble(
     x = c(1, 2),
     y = c(10, 20),
-    z = c(100, 200),
+    z = c(100, 200)
   )
   pv <- data_to_long(df, 1:3)
 
-  expect_equal(pv$value, c(1, 10, 100, 2, 20, 200))
+  expect_identical(pv$value, c(1, 10, 100, 2, 20, 200))
 })
 
 test_that("preserves original keys", {
@@ -438,7 +438,7 @@ test_that("preserves original keys", {
   pv <- data_to_long(df, y:z)
 
   expect_named(pv, c("x", "name", "value"))
-  expect_equal(pv$x, rep(df$x, each = 2))
+  expect_identical(pv$x, rep(df$x, each = 2))
 })
 
 test_that("can drop missing values", {
@@ -448,8 +448,8 @@ test_that("can drop missing values", {
   df <- data.frame(x = c(1, NA), y = c(NA, 2))
   pv <- data_to_long(df, x:y, values_drop_na = TRUE)
 
-  expect_equal(pv$name, c("x", "y"))
-  expect_equal(pv$value, c(1, 2))
+  expect_identical(pv$name, c("x", "y"))
+  expect_identical(pv$value, c(1, 2))
 })
 
 test_that("mixed columns are automatically coerced", {
@@ -459,7 +459,7 @@ test_that("mixed columns are automatically coerced", {
   df <- data.frame(x = factor("a"), y = factor("b"))
   pv <- data_to_long(df, x:y)
 
-  expect_equal(pv$value, factor(c("a", "b")))
+  expect_identical(pv$value, factor(c("a", "b")))
 })
 
 test_that("error when overwriting existing column", {

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -14,7 +14,8 @@ test_that("data_to_long works", {
   )
 
   expect_equal(
-    head(data_to_long(wide_data,
+    head(data_to_long(
+      wide_data,
       select = c(1, 2),
       names_to = "Column",
       values_to = "Numbers",
@@ -485,7 +486,7 @@ test_that("preserve date format", {
   )
 
   tidyr <- tidyr::pivot_longer(family, !family, names_to = "child")
-  datawiz <- data_to_long(family, -c("family"), names_to = "child")
+  datawiz <- data_to_long(family, -family, names_to = "child")
 
   expect_identical(tidyr, datawiz)
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -5,7 +5,8 @@ test_that("data_to_wide works", {
       "X1", "X1", "X1", "X1", "X1", "X2", "X2", "X2", "X2", "X2",
       "X3", "X3", "X3", "X3", "X3"
     ),
-    value = c(3L, 2L, 5L, 4L, 1L, 3L, 1L, 2L, 5L, 4L, 2L, 3L, 1L, 4L, 5L)
+    value = c(3L, 2L, 5L, 4L, 1L, 3L, 1L, 2L, 5L, 4L, 2L, 3L, 1L, 4L, 5L),
+    stringsAsFactors = FALSE
   )
 
   expect_equal(
@@ -51,8 +52,8 @@ test_that("data_to_wide, names_prefix works", {
       names_prefix = "foo_"
     )
 
-  expect_equal(
-    names(out),
+  expect_named(
+    out,
     c(
       "fish", "foo_Release", "foo_I80_1", "foo_Lisbon", "foo_Rstr", "foo_Base_TD",
       "foo_BCE", "foo_BCW", "foo_BCE2", "foo_BCW2", "foo_MAE", "foo_MAW"
@@ -88,7 +89,7 @@ test_that("data_to_wide, values_fill works", {
       Lisbon = c(1, 1, 1),
       BCW2 = c(1, 1, 1),
       MAE = c(1, 1, 1),
-      MAW = c(1, 1, 1),
+      MAW = c(1, 1, 1)
     )
   )
   expect_error(
@@ -130,7 +131,7 @@ test_that("data_to_wide, values_fill works", {
     tibble(
       person_id = 1:3,
       name = c("Jiena McLellan", "John Smith", "Huxley Ratcliffe"),
-      company = c("Toyota", "foo", "foo"),
+      company = c("Toyota", "foo", "foo")
     )
   )
   expect_error(
@@ -207,7 +208,7 @@ test_that("can pivot all cols to wide", {
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
 
   expect_named(pv, c("x", "y", "z"))
-  expect_equal(nrow(pv), 1)
+  expect_identical(nrow(pv), 1L)
 })
 
 test_that("non-pivoted cols are preserved", {
@@ -218,7 +219,7 @@ test_that("non-pivoted cols are preserved", {
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
 
   expect_named(pv, c("a", "x", "y"))
-  expect_equal(nrow(pv), 1)
+  expect_identical(nrow(pv), 1L)
 })
 
 test_that("implicit missings turn into explicit missings", {
@@ -228,9 +229,9 @@ test_that("implicit missings turn into explicit missings", {
   df <- tibble(a = 1:2, key = c("x", "y"), val = 1:2)
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
 
-  expect_equal(pv$a, c(1, 2))
-  expect_equal(pv$x, c(1, NA))
-  expect_equal(pv$y, c(NA, 2))
+  expect_identical(pv$a, c(1L, 2L))
+  expect_identical(pv$x, c(1L, NA))
+  expect_identical(pv$y, c(NA, 2L))
 })
 
 test_that("error when overwriting existing column", {
@@ -454,9 +455,10 @@ test_that("data_to_wide, names_glue works", {
 
   df <- data.frame(
     food = c("banana", "banana", "banana", "banana", "cheese", "cheese", "cheese", "cheese"),
-    binary = c(rep(c("yes", "no"), 4)),
+    binary = rep(c("yes", "no"), 4),
     car = c("toyota", "subaru", "mazda", "skoda", "toyota", "subaru", "mazda", "skoda"),
-    fun = c(2, 4, 3, 6, 2, 4, 2, 3)
+    fun = c(2, 4, 3, 6, 2, 4, 2, 3),
+    stringsAsFactors = FALSE
   )
 
   x <- df %>%
@@ -535,12 +537,12 @@ test_that("new names starting with digits are not corrected automatically", {
   tidyr <- tidyr::pivot_wider(
     percentages,
     names_from = c(year, type),
-    values_from = percentage,
+    values_from = percentage
   )
   datawiz <- data_to_wide(
     percentages,
     names_from = c("year", "type"),
-    values_from = "percentage",
+    values_from = "percentage"
   )
   expect_identical(tidyr, datawiz)
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -42,7 +42,7 @@ test_that("data_to_wide works", {
 
 test_that("data_to_wide, names_prefix works", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   out <- fish_encounters %>%
     data_to_wide(
@@ -62,7 +62,7 @@ test_that("data_to_wide, names_prefix works", {
 
 test_that("data_to_wide, values_fill works", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   data <- fish_encounters[c(1:3, 20:25), ]
 
@@ -176,7 +176,7 @@ test_that("data_to_wide, values_fill works", {
 
 test_that("data_to_wide, values_fill errors when length > 1", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   expect_error(
     fish_encounters %>%
@@ -201,7 +201,7 @@ test_that("data_to_wide, values_fill errors when length > 1", {
 
 test_that("can pivot all cols to wide", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(key = c("x", "y", "z"), val = 1:3)
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
@@ -212,7 +212,7 @@ test_that("can pivot all cols to wide", {
 
 test_that("non-pivoted cols are preserved", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(a = 1, key = c("x", "y"), val = 1:2)
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
@@ -223,7 +223,7 @@ test_that("non-pivoted cols are preserved", {
 
 test_that("implicit missings turn into explicit missings", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(a = 1:2, key = c("x", "y"), val = 1:2)
   pv <- data_to_wide(df, names_from = "key", values_from = "val")
@@ -235,7 +235,7 @@ test_that("implicit missings turn into explicit missings", {
 
 test_that("error when overwriting existing column", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- tibble(
     a = c(1, 1),
@@ -251,7 +251,7 @@ test_that("error when overwriting existing column", {
 
 test_that("data_to_wide: fill values, #293", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   weekdays <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
@@ -279,7 +279,7 @@ test_that("data_to_wide: fill values, #293", {
 
 test_that("data_to_wide, id_cols works correctly, #293", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   updates <- tibble(
     county = c("Wake", "Wake", "Wake", "Guilford", "Guilford"),
@@ -309,7 +309,7 @@ test_that("data_to_wide, id_cols works correctly, #293", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 1", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- fish_encounters %>%
     tidyr::pivot_wider(names_from = "station", values_from = "seen", values_fill = 0)
@@ -326,7 +326,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 1", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 2", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   production <- expand_grid(
     product = c("A", "B"),
@@ -354,7 +354,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 2", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 3", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- us_rent_income %>%
     tidyr::pivot_wider(
@@ -373,7 +373,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 3", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 4", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   x <- us_rent_income %>%
     tidyr::pivot_wider(
@@ -394,7 +394,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 4", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 5", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   contacts <- tribble(
     ~field, ~value,
@@ -419,7 +419,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 5", {
 
 test_that("data_to_wide equivalent to pivot_wider: ex 6", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   production <- expand_grid(
     product = c("A", "B"),
@@ -450,7 +450,7 @@ test_that("data_to_wide equivalent to pivot_wider: ex 6", {
 
 test_that("data_to_wide, names_glue works", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   df <- data.frame(
     food = c("banana", "banana", "banana", "banana", "cheese", "cheese", "cheese", "cheese"),
@@ -482,7 +482,7 @@ test_that("data_to_wide, names_glue works", {
 
 test_that("preserve date format", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   family <- tibble(
     family = c(1L, 1L, 2L, 2L, 3L, 3L),
@@ -506,7 +506,7 @@ test_that("preserve date format", {
 
 test_that("#293", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   weekdays <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
 
@@ -524,7 +524,7 @@ test_that("#293", {
 
 test_that("new names starting with digits are not corrected automatically", {
   skip_if_not_installed("tidyr")
-  library(tidyr)
+  suppressPackageStartupMessages(library(tidyr))
 
   percentages <- tibble(
     year = c(2018, 2019, 2020, 2020),

--- a/tests/testthat/test-data_unique.R
+++ b/tests/testthat/test-data_unique.R
@@ -55,49 +55,49 @@ test_that("data_unique returns original data if no duplicates", {
 })
 
 test_that("data_unique basic", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = "id", verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique basic method best", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = "id", keep = "best", verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique basic method first", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = "id", keep = "first", verbose = FALSE),
     expected2
   )
 })
 
 test_that("data_unique basic method last", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = "id", keep = "last", verbose = FALSE),
     expected3
   )
 })
 
 test_that("data_unique unquoted", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = id, verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique vector", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = 1, verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique select-helper", {
-  expect_equal(
+  expect_identical(
     data_unique(df1, select = contains("id"), verbose = FALSE),
     expected1
   )
@@ -106,7 +106,7 @@ test_that("data_unique select-helper", {
 test_that("data_unique multiple IDs", {
   x <- data_unique(df1, select = c("id", "year"), verbose = FALSE)
   rownames(x) <- NULL
-  expect_equal(
+  expect_identical(
     x,
     expected4
   )
@@ -115,7 +115,7 @@ test_that("data_unique multiple IDs", {
 test_that("data_unique multiple IDs formula", {
   x <- data_unique(df1, select = ~ id + year, verbose = FALSE)
   rownames(x) <- NULL
-  expect_equal(
+  expect_identical(
     x,
     expected4
   )
@@ -124,7 +124,7 @@ test_that("data_unique multiple IDs formula", {
 test_that("data_unique multiple IDs vector", {
   x <- data_unique(df1, select = 1:2, verbose = FALSE)
   rownames(x) <- NULL
-  expect_equal(
+  expect_identical(
     x,
     expected4
   )
@@ -133,7 +133,7 @@ test_that("data_unique multiple IDs vector", {
 test_that("data_unique preserve attributes", {
   attr(df1, "testing") <- "custom.attribute"
   x <- attributes(data_unique(df1, id, verbose = FALSE))
-  expect_equal(
+  expect_identical(
     x$testing,
     "custom.attribute"
   )

--- a/tests/testthat/test-data_unique.R
+++ b/tests/testthat/test-data_unique.R
@@ -45,66 +45,66 @@ expected4 <- data.frame(
 test_that("data_unique returns original data if no duplicates", {
   test <- data.frame(x = c(1, 2), y = c(3, 4))
   expect_identical(
-    data_unique(test, c("x", "y")),
+    data_unique(test, c("x", "y"), verbose = FALSE),
     test
   )
   expect_identical(
-    data_unique(test, "x"),
+    data_unique(test, "x", verbose = FALSE),
     test
   )
 })
 
 test_that("data_unique basic", {
   expect_equal(
-    data_unique(df1, select = "id"),
+    data_unique(df1, select = "id", verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique basic method best", {
   expect_equal(
-    data_unique(df1, select = "id", keep = "best"),
+    data_unique(df1, select = "id", keep = "best", verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique basic method first", {
   expect_equal(
-    data_unique(df1, select = "id", keep = "first"),
+    data_unique(df1, select = "id", keep = "first", verbose = FALSE),
     expected2
   )
 })
 
 test_that("data_unique basic method last", {
   expect_equal(
-    data_unique(df1, select = "id", keep = "last"),
+    data_unique(df1, select = "id", keep = "last", verbose = FALSE),
     expected3
   )
 })
 
 test_that("data_unique unquoted", {
   expect_equal(
-    data_unique(df1, select = id),
+    data_unique(df1, select = id, verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique vector", {
   expect_equal(
-    data_unique(df1, select = 1),
+    data_unique(df1, select = 1, verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique select-helper", {
   expect_equal(
-    data_unique(df1, select = contains("id")),
+    data_unique(df1, select = contains("id"), verbose = FALSE),
     expected1
   )
 })
 
 test_that("data_unique multiple IDs", {
-  x <- data_unique(df1, select = c("id", "year"))
+  x <- data_unique(df1, select = c("id", "year"), verbose = FALSE)
   rownames(x) <- NULL
   expect_equal(
     x,
@@ -113,7 +113,7 @@ test_that("data_unique multiple IDs", {
 })
 
 test_that("data_unique multiple IDs formula", {
-  x <- data_unique(df1, select = ~ id + year)
+  x <- data_unique(df1, select = ~ id + year, verbose = FALSE)
   rownames(x) <- NULL
   expect_equal(
     x,
@@ -122,7 +122,7 @@ test_that("data_unique multiple IDs formula", {
 })
 
 test_that("data_unique multiple IDs vector", {
-  x <- data_unique(df1, select = 1:2)
+  x <- data_unique(df1, select = 1:2, verbose = FALSE)
   rownames(x) <- NULL
   expect_equal(
     x,
@@ -132,7 +132,7 @@ test_that("data_unique multiple IDs vector", {
 
 test_that("data_unique preserve attributes", {
   attr(df1, "testing") <- "custom.attribute"
-  x <- attributes(data_unique(df1, id))
+  x <- attributes(data_unique(df1, id, verbose = FALSE))
   expect_equal(
     x$testing,
     "custom.attribute"
@@ -140,8 +140,9 @@ test_that("data_unique preserve attributes", {
 })
 
 test_that("data_unique, arg 'verbose' works", {
-  expect_silent(
-    data_unique(df1, select = ~ id + year, verbose = FALSE)
+  expect_message(
+    data_unique(df1, select = ~ id + year),
+    "removed, with method"
   )
 })
 
@@ -158,7 +159,7 @@ test_that("data_unique works with groups", {
   )
   expected <- data_group(expected, "g")
 
-  x <- data_unique(df, "x")
+  x <- data_unique(df, "x", verbose = FALSE)
   expect_identical(x, expected, ignore_attr = TRUE)
 
   y <- attributes(x)

--- a/tests/testthat/test-demean.R
+++ b/tests/testthat/test-demean.R
@@ -5,7 +5,7 @@ test_that("demean works", {
   df$ID <- sample(1:4, nrow(df), replace = TRUE) # fake-ID
 
   set.seed(123)
-  df$binary <- as.factor(rbinom(150, 1, .35)) # binary variable
+  df$binary <- as.factor(rbinom(150, 1, 0.35)) # binary variable
 
   set.seed(123)
   x <- demean(df, select = c("Sepal.Length", "Petal.Length"), group = "ID")
@@ -27,7 +27,7 @@ test_that("demean works", {
     z <- demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID"),
     "have been coerced to numeric"
   )
-  expect_equal(y, z)
+  expect_identical(y, z)
 })
 
 test_that("demean interaction term", {
@@ -52,7 +52,7 @@ test_that("demean shows message if some vars don't exist", {
 
   set.seed(123)
   expect_message(
-    demean(dat, select = c("foo"), group = "ID"),
+    demean(dat, select = "foo", group = "ID"),
     regexp = "not found"
   )
 })

--- a/tests/testthat/test-demean.R
+++ b/tests/testthat/test-demean.R
@@ -12,14 +12,22 @@ test_that("demean works", {
   expect_snapshot(head(x))
 
   set.seed(123)
-  x <- demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID")
+  expect_message(
+    x <- demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID"),
+    "have been coerced to numeric"
+  )
   expect_snapshot(head(x))
 
   set.seed(123)
-  expect_equal(
-    demean(df, select = ~ Sepal.Length + binary + Species, group = ~ID),
-    demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID")
+  expect_message(
+    y <- demean(df, select = ~ Sepal.Length + binary + Species, group = ~ID),
+    "have been coerced to numeric"
   )
+  expect_message(
+    z <- demean(df, select = c("Sepal.Length", "binary", "Species"), group = "ID"),
+    "have been coerced to numeric"
+  )
+  expect_equal(y, z)
 })
 
 test_that("demean interaction term", {

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -119,7 +119,7 @@ test_that("normalize: matrix", {
 
 test_that("normalize: select", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     normalize(
@@ -133,7 +133,7 @@ test_that("normalize: select", {
 
 test_that("normalize: exclude", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     normalize(
@@ -150,7 +150,7 @@ test_that("normalize: exclude", {
 
 test_that("normalize (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   datawizard <- iris %>%
     group_by(Species) %>%
@@ -169,7 +169,7 @@ test_that("normalize (grouped data)", {
 
 test_that("normalize, include bounds (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   datawizard <- iris %>%
     group_by(Species) %>%
@@ -189,7 +189,7 @@ test_that("normalize, include bounds (grouped data)", {
 
 test_that("normalize, factor (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   datawizard <- iris %>%
     group_by(Species) %>%

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -12,7 +12,7 @@ test_that("normalize work as expected", {
   )
 
   expect_equal(
-    normalize(c(0, 1, 5, -5, -2), include_bounds = .01),
+    normalize(c(0, 1, 5, -5, -2), include_bounds = 0.01),
     c(0.5, 0.598, 0.99, 0.01, 0.304),
     ignore_attr = TRUE,
     tolerance = 1e-4
@@ -77,7 +77,7 @@ test_that("normalize: all Na or Inf", {
 
 
 test_that("normalize: only one value", {
-  foo <- c(1)
+  foo <- 1
   expect_warning(
     normalize(x = foo),
     regexp = "Variable `foo` contains only one unique value and will"
@@ -103,8 +103,8 @@ test_that("normalize: only two values", {
 })
 
 test_that("normalize: factor", {
-  expect_equal(
-    normalize(factor(c(1:3))),
+  expect_identical(
+    normalize(factor(1:3)),
     factor(1:3)
   )
 })
@@ -121,7 +121,7 @@ test_that("normalize: select", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     normalize(
       iris,
       select = starts_with("Petal\\.L")
@@ -135,7 +135,7 @@ test_that("normalize: exclude", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     normalize(
       iris,
       exclude = ends_with("ecies")
@@ -164,7 +164,7 @@ test_that("normalize (grouped data)", {
     ungroup() %>%
     pull(Sepal.Width)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 test_that("normalize, include bounds (grouped data)", {
@@ -183,7 +183,7 @@ test_that("normalize, include bounds (grouped data)", {
     ungroup() %>%
     pull(Sepal.Width)
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 
@@ -199,12 +199,12 @@ test_that("normalize, factor (grouped data)", {
 
   manual <- iris$Species
 
-  expect_equal(datawizard, manual)
+  expect_identical(datawizard, manual)
 })
 
 # select helpers ------------------------------
 test_that("normalize regex", {
-  expect_equal(
+  expect_identical(
     normalize(mtcars, select = "pg", regex = TRUE),
     normalize(mtcars, select = "mpg")
   )

--- a/tests/testthat/test-ranktransform.R
+++ b/tests/testthat/test-ranktransform.R
@@ -1,17 +1,17 @@
 test_that("ranktransform works with NAs", {
   x <- c(NA_real_, NA_real_)
-  expect_equal(ranktransform(x), x)
+  expect_identical(ranktransform(x), x)
 })
 
 test_that("ranktransform works with factors", {
   x <- factor(c("apple", "bear", "banana", "dear"))
-  expect_equal(ranktransform(x), x)
+  expect_identical(ranktransform(x), x)
 })
 
 test_that("ranktransform works with unique value vectors", {
   x <- c(1L, 1L, 1L)
 
-  expect_equal(suppressWarnings(ranktransform(x)), x)
+  expect_identical(suppressWarnings(ranktransform(x)), x)
 
   expect_warning(
     ranktransform(x),
@@ -22,7 +22,7 @@ test_that("ranktransform works with unique value vectors", {
 test_that("ranktransform works with two unique value vectors", {
   x <- c(1L, 1L, 1L, 2L, 2L, 2L)
 
-  expect_equal(suppressWarnings(ranktransform(x)), c(2, 2, 2, 5, 5, 5))
+  expect_identical(suppressWarnings(ranktransform(x)), c(2, 2, 2, 5, 5, 5))
 
   expect_warning(
     ranktransform(x),
@@ -36,8 +36,8 @@ test_that("signed rank works as expected", {
   sr <- ranktransform(x, sign = TRUE)
   r <- ranktransform(x, sign = FALSE)
 
-  expect_equal(sr, x) # unchanged
-  expect_equal(r, c(2, 3, 1, 4))
+  expect_identical(sr, x) # unchanged
+  expect_identical(r, c(2, 3, 1, 4))
 
   x <- c(1, -2, -2, 4, 0, 3, -14, 0)
   expect_warning(ranktransform(x, sign = TRUE))
@@ -63,14 +63,15 @@ value2 <- sample(1:20, 9, replace = TRUE)
 test_df <- data.frame(
   id = rep(c("A", "B", "C"), each = 3),
   value1 = value1,
-  value2 = value2
+  value2 = value2,
+  stringsAsFactors = FALSE
 )
 
 test_that("ranktransform works with data frames (grouped data)", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     test_df %>%
       group_by(id) %>%
       ranktransform(exclude = "id") %>%
@@ -78,7 +79,8 @@ test_that("ranktransform works with data frames (grouped data)", {
     data.frame(
       id = rep(c("A", "B", "C"), each = 3),
       value1 = c(2, 3, 1, 1, 2, 3, 2, 1, 3),
-      value2 = c(3, 2, 1, 1, 3, 2, 2, 3, 1)
+      value2 = c(3, 2, 1, 1, 3, 2, 2, 3, 1),
+      stringsAsFactors = FALSE
     )
   )
 })
@@ -93,14 +95,15 @@ value2 <- sample(c(1:15, NA), 9, replace = TRUE)
 test_df <- data.frame(
   id = rep(c("A", "B", "C"), each = 3),
   value1 = value1,
-  value2 = value2
+  value2 = value2,
+  stringsAsFactors = FALSE
 )
 
 test_that("ranktransform works with data frames containing NAs (grouped data)", {
   skip_if_not_installed("poorman")
   suppressPackageStartupMessages(library(poorman))
 
-  expect_equal(
+  expect_identical(
     test_df %>%
       group_by(id) %>%
       ranktransform(exclude = "id") %>%
@@ -108,14 +111,15 @@ test_that("ranktransform works with data frames containing NAs (grouped data)", 
     data.frame(
       id = rep(c("A", "B", "C"), each = 3),
       value1 = c(2, NA, 1, 1, 3, 2, 2, NA, 1),
-      value2 = c(3, 1, 2, NA, 2, 1, 3, 1, 2)
+      value2 = c(3, 1, 2, NA, 2, 1, 3, 1, 2),
+      stringsAsFactors = FALSE
     )
   )
 })
 
 # select helpers ------------------------------
 test_that("ranktransform regex", {
-  expect_equal(
+  expect_identical(
     ranktransform(mtcars, select = "pg", regex = TRUE),
     ranktransform(mtcars, select = "mpg")
   )

--- a/tests/testthat/test-ranktransform.R
+++ b/tests/testthat/test-ranktransform.R
@@ -68,7 +68,7 @@ test_df <- data.frame(
 
 test_that("ranktransform works with data frames (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     test_df %>%
@@ -98,7 +98,7 @@ test_df <- data.frame(
 
 test_that("ranktransform works with data frames containing NAs (grouped data)", {
   skip_if_not_installed("poorman")
-  library(poorman)
+  suppressPackageStartupMessages(library(poorman))
 
   expect_equal(
     test_df %>%


### PR DESCRIPTION
Close #344 

Mostly just add `verbose = FALSE` or sth equivalent. Please take a look at `test-data_cut.R` to be sure the behavior is correct (it currently prints 2 different messages for `NA` and `NA_real_`)