### PR TITLE
Fix `empty_columns` with only `NA_character_`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.5.3
+Version: 0.6.5.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@ MINOR CHANGES
 
 * `data_rename()` gets a `verbose` argument.
 
+BUG FIXES
+
+* `empty_columns()` (and therefore `remove_empty_columns()`) now correctly detects
+  columns containing only `NA_character_` (#349).
+
 # datawizard 0.6.5
 
 MAJOR CHANGES

--- a/R/remove_empty.R
+++ b/R/remove_empty.R
@@ -63,7 +63,7 @@ empty_columns <- function(x) {
   } else {
     all_na <- colSums(is.na(x)) == nrow(x)
     all_empty <- vapply(x, function(i) {
-      (is.character(i) || is.factor(i)) && max(nchar(as.character(i)), na.rm = TRUE) == 0
+      (is.character(i) || is.factor(i)) && max(c(0, nchar(as.character(i))), na.rm = TRUE) == 0
     }, FUN.VALUE = logical(1L))
 
     which(all_na | all_empty)

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,3 +1,6 @@
-if(requireNamespace('spelling', quietly = TRUE))
-  spelling::spell_check_test(vignettes = TRUE, error = FALSE,
-                             skip_on_cran = TRUE)
+if (requireNamespace("spelling", quietly = TRUE)) {
+  spelling::spell_check_test(
+    vignettes = TRUE, error = FALSE,
+    skip_on_cran = TRUE
+  )
+}

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,6 +1,0 @@
-if (requireNamespace("spelling", quietly = TRUE)) {
-  spelling::spell_check_test(
-    vignettes = TRUE, error = FALSE,
-    skip_on_cran = TRUE
-  )
-}

--- a/tests/testthat/test-empty-dataframe.R
+++ b/tests/testthat/test-empty-dataframe.R
@@ -6,12 +6,12 @@ test_that("remove empty with character", {
     d = c(1, NA, 3, NA, 5)
   )
 
-  expect_equal(empty_columns(tmp), c(c = 3L))
-  expect_equal(empty_rows(tmp), 4)
+  expect_identical(empty_columns(tmp), c(c = 3L))
+  expect_identical(empty_rows(tmp), 4L)
 
-  expect_equal(dim(remove_empty_columns(tmp)), c(5L, 3L))
-  expect_equal(dim(remove_empty_rows(tmp)), c(4L, 4L))
-  expect_equal(dim(remove_empty(tmp)), c(4L, 3L))
+  expect_identical(dim(remove_empty_columns(tmp)), c(5L, 3L))
+  expect_identical(dim(remove_empty_rows(tmp)), c(4L, 4L))
+  expect_identical(dim(remove_empty(tmp)), c(4L, 3L))
 
   expect_snapshot(remove_empty_columns(tmp))
   expect_snapshot(remove_empty_rows(tmp))
@@ -29,9 +29,9 @@ test_that("remove empty columns with character", {
     stringsAsFactors = FALSE
   )
 
-  expect_equal(empty_columns(tmp), c(b = 2L, c = 3L, e = 5L))
-  expect_equal(dim(remove_empty_columns(tmp)), c(5L, 2L))
-  expect_equal(dim(remove_empty(tmp)), c(4L, 2L))
+  expect_identical(empty_columns(tmp), c(b = 2L, c = 3L, e = 5L))
+  expect_identical(dim(remove_empty_columns(tmp)), c(5L, 2L))
+  expect_identical(dim(remove_empty(tmp)), c(4L, 2L))
 })
 
 
@@ -47,7 +47,15 @@ test_that("remove empty rows with character", {
     stringsAsFactors = FALSE
   )
 
-  expect_equal(empty_rows(tmp), c(2L, 4L))
-  expect_equal(dim(remove_empty_rows(tmp)), c(3L, 7L))
-  expect_equal(dim(remove_empty(tmp)), c(3L, 2L))
+  expect_identical(empty_rows(tmp), c(2L, 4L))
+  expect_identical(dim(remove_empty_rows(tmp)), c(3L, 7L))
+  expect_identical(dim(remove_empty(tmp)), c(3L, 2L))
+})
+
+test_that("empty_columns with only NA characters", {
+  tmp <- data.frame(
+    var1 = c(1, 1, 1),
+    var2 = c(NA_character_, NA_character_, NA_character_)
+  )
+  expect_identical(empty_columns(tmp), c(var2 = 2L))
 })


### PR DESCRIPTION
Close #349 

``` r
library(datawizard)
options(warn = 2L)
load("test.RData")
datawizard::remove_empty(out)
#>                Parameter     Median   CI     CI_low    CI_high pd   Component
#> 1                     mu 64.6462056 0.95 61.9670930 67.3660318  1       extra
#> 2             complaints  0.7245799 0.95  0.5067928  0.9187746  1       extra
#> 3                   sig2 52.2962092 0.95 31.5455269 92.1527877  1       extra
#> 4                      g  1.3570011 0.95  0.1953671 38.2999735  1       extra
#> 5        advance-advance         NA   NA         NA         NA NA conditional
#> 6  complaints-complaints         NA   NA         NA         NA NA conditional
#> 7      critical-critical         NA   NA         NA         NA NA conditional
#> 8      learning-learning         NA   NA         NA         NA NA conditional
#> 9  privileges-privileges         NA   NA         NA         NA NA conditional
#> 10         raises-raises         NA   NA         NA         NA NA conditional
```

<sup>Created on 2023-01-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>