### PR TITLE
`winsorize`: change warnings to errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.5.4
+Version: 0.6.5.5
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@ NEW FUNCTIONS
 MINOR CHANGES
 
 * `data_rename()` gets a `verbose` argument.
+* `winsorize()` now errors if the threshold is incorrect (previously, it provided
+  a warning and returned the unchanged data). The argument `verbose` is now 
+  useless but is kept for backward compatibility. The documentation now contains   
+  details about the valid values for `threshold` (#357).
 
 BUG FIXES
 

--- a/R/winsorize.R
+++ b/R/winsorize.R
@@ -96,16 +96,14 @@ winsorize.numeric <- function(data,
                               threshold = 0.2,
                               method = "percentile",
                               robust = FALSE,
-                              verbose,
+                              verbose = TRUE,
                               ...) {
   method <- match.arg(method, choices = c("percentile", "zscore", "raw"))
 
-  if (method == "raw") {
-    if (length(threshold) != 2L) {
-      insight::format_error(
-        "`threshold` must be of length 2 for lower and upper bound."
-      )
-    }
+  if (method == "raw" && length(threshold) != 2L) {
+    insight::format_error(
+      "`threshold` must be of length 2 for lower and upper bound."
+    )
   }
 
   if (method == "percentile") {

--- a/R/winsorize.R
+++ b/R/winsorize.R
@@ -19,8 +19,12 @@
 #' @param data data frame or vector.
 #' @param threshold The amount of winsorization, depends on the value of `method`:
 #' - For `method = "percentile"`: the amount to winsorize from *each* tail.
-#' - For `method = "zscore"`: the number of *SD*/*MAD*-deviations from the *mean*/*median* (see `robust`)
-#' - For `method = "raw"`: a vector of length 2 with the lower and upper bound for winsorization.
+#'   The value of `threshold` must be between 0 and 0.5 and of length 1.
+#' - For `method = "zscore"`: the number of *SD*/*MAD*-deviations from the
+#'   *mean*/*median* (see `robust`). The value of `threshold` must be greater
+#'   than 0 and of length 1.
+#' - For `method = "raw"`: a vector of length 2 with the lower and upper bound
+#'   for winsorization.
 #' @param verbose Toggle warnings.
 #' @param method One of "percentile" (default), "zscore", or "raw".
 #' @param robust Logical, if TRUE, winsorizing through the "zscore" method is
@@ -92,31 +96,23 @@ winsorize.numeric <- function(data,
                               threshold = 0.2,
                               method = "percentile",
                               robust = FALSE,
-                              verbose = TRUE,
+                              verbose,
                               ...) {
   method <- match.arg(method, choices = c("percentile", "zscore", "raw"))
 
   if (method == "raw") {
     if (length(threshold) != 2L) {
-      if (isTRUE(verbose)) {
-        insight::format_warning(
-          "`threshold` must be of length 2 for lower and upper bound.",
-          "Did not winsorize data."
-        )
-      }
-      return(data)
+      insight::format_error(
+        "`threshold` must be of length 2 for lower and upper bound."
+      )
     }
   }
 
   if (method == "percentile") {
     if (threshold < 0 || threshold > 0.5) {
-      if (isTRUE(verbose)) {
-        insight::format_warning(
-          "`threshold` for winsorization must be a scalar between 0 and 0.5.",
-          "Did not winsorize data."
-        )
-      }
-      return(data)
+      insight::format_error(
+        "`threshold` for winsorization must be a scalar between 0 and 0.5."
+      )
     }
 
     y <- sort(data)
@@ -129,12 +125,9 @@ winsorize.numeric <- function(data,
 
   if (method == "zscore") {
     if (threshold <= 0) {
-      if (isTRUE(verbose)) {
-        insight::format_warning(
-          "'threshold' for winsorization must be a scalar greater than 0. Did not winsorize data."
-        )
-      }
-      return(data)
+      insight::format_error(
+        "'threshold' for winsorization must be a scalar greater than 0."
+      )
     }
 
     if (isTRUE(robust)) {

--- a/man/winsorize.Rd
+++ b/man/winsorize.Rd
@@ -12,7 +12,7 @@ winsorize(data, ...)
   threshold = 0.2,
   method = "percentile",
   robust = FALSE,
-  verbose = TRUE,
+  verbose,
   ...
 )
 }
@@ -24,8 +24,12 @@ winsorize(data, ...)
 \item{threshold}{The amount of winsorization, depends on the value of \code{method}:
 \itemize{
 \item For \code{method = "percentile"}: the amount to winsorize from \emph{each} tail.
-\item For \code{method = "zscore"}: the number of \emph{SD}/\emph{MAD}-deviations from the \emph{mean}/\emph{median} (see \code{robust})
-\item For \code{method = "raw"}: a vector of length 2 with the lower and upper bound for winsorization.
+The value of \code{threshold} must be between 0 and 0.5 and of length 1.
+\item For \code{method = "zscore"}: the number of \emph{SD}/\emph{MAD}-deviations from the
+\emph{mean}/\emph{median} (see \code{robust}). The value of \code{threshold} must be greater
+than 0 and of length 1.
+\item For \code{method = "raw"}: a vector of length 2 with the lower and upper bound
+for winsorization.
 }}
 
 \item{method}{One of "percentile" (default), "zscore", or "raw".}

--- a/man/winsorize.Rd
+++ b/man/winsorize.Rd
@@ -12,7 +12,7 @@ winsorize(data, ...)
   threshold = 0.2,
   method = "percentile",
   robust = FALSE,
-  verbose,
+  verbose = TRUE,
   ...
 )
 }

--- a/tests/testthat/test-winsorization.R
+++ b/tests/testthat/test-winsorization.R
@@ -10,33 +10,26 @@ test_that("with missing values", {
 })
 
 test_that("winsorize: threshold must be between 0 and 1", {
-  expect_warning(
+  expect_error(
     winsorize(sample(1:10, 5), threshold = -0.1),
     regexp = "must be a scalar between 0 and 0.5"
   )
-  expect_warning(
+  expect_error(
     winsorize(sample(1:10, 5), threshold = 1.1),
     regexp = "must be a scalar between 0 and 0.5"
   )
-  expect_warning(
+  expect_error(
     winsorize(sample(1:10, 5), method = "zscore", threshold = -3),
     regexp = "must be a scalar greater than 0"
   )
-  expect_warning(
+  expect_error(
     winsorize(sample(1:10, 5), method = "zscore", threshold = -3, robust = TRUE),
     regexp = "must be a scalar greater than 0"
   )
-  expect_warning(
+  expect_error(
     winsorize(sample(1:10, 5), method = "raw", threshold = 1.1),
     regexp = "must be of length 2 for lower and upper bound"
   )
-  x <- sample(1:10, 5)
-  suppressWarnings({
-    y <- winsorize(x, threshold = -0.1)
-    z <- winsorize(x, threshold = 1.1)
-  })
-  expect_equal(x, y)
-  expect_equal(x, z)
 })
 
 test_that("winsorize on data.frame", {

--- a/tests/testthat/test-winsorization.R
+++ b/tests/testthat/test-winsorization.R
@@ -1,5 +1,5 @@
 test_that("testing Winsorization of factors", {
-  expect_equal(winsorize(as.factor(mtcars$am)), as.factor(mtcars$am))
+  expect_identical(winsorize(as.factor(mtcars$am)), as.factor(mtcars$am))
 })
 
 test_that("with missing values", {
@@ -34,11 +34,11 @@ test_that("winsorize: threshold must be between 0 and 1", {
 
 test_that("winsorize on data.frame", {
   iris2 <- winsorize(iris)
-  expect_equal(
+  expect_identical(
     iris2$Sepal.Length,
     winsorize(iris$Sepal.Length)
   )
-  expect_equal(
+  expect_identical(
     iris2$Petal.Width,
     winsorize(iris$Petal.Width)
   )


### PR DESCRIPTION
Close #357 

New behavior:
``` r
library(datawizard)

winsorize(1:3, threshold = 1.2)
#> Error: `threshold` for winsorization must be a scalar between 0 and 0.5.
```