### PR TITLE
Refactor `convert_na_to`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.6.5.6
+Version: 0.6.5.7
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ BUG FIXES
   columns containing only `NA_character_` (#349).
 * Select helpers now work in custom functions when argument is called `select`
   (#356).
+* Fix unexpected warning in `convert_na_to()` when `select` is a list (#352).
 
 # datawizard 0.6.5
 

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -161,8 +161,7 @@ convert_na_to.data.frame <- function(x,
                                      verbose = TRUE,
                                      ...) {
   data <- x
-  select_nse <- .select_nse(
-    select,
+  select_nse <- .select_nse(select,
     data,
     exclude = exclude,
     ignore_case,
@@ -170,17 +169,16 @@ convert_na_to.data.frame <- function(x,
     verbose = verbose
   )
 
-  .replace_by_type <- function(y) {
-    switch(class(y),
-      "integer" = ,
-      "numeric" = replace_num,
-      "character" = replace_char,
-      "factor" = replace_fac
-    )
-  }
-
   # default
-  lookup <- lapply(x, .replace_by_type)
+  lookup <- lapply(x, function(y) {
+    if (is.numeric(y)) {
+      replace_num
+    } else if (is.character(y)) {
+      replace_char
+    } else if (is.factor(y)) {
+      replace_fac
+    }
+  })
 
   # override for specific vars
   try_eval <- try(eval(select), silent = TRUE)

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -161,7 +161,8 @@ convert_na_to.data.frame <- function(x,
                                      verbose = TRUE,
                                      ...) {
   data <- x
-  select_nse <- .select_nse(select,
+  select_nse <- .select_nse(
+    select,
     data,
     exclude = exclude,
     ignore_case,

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -169,60 +169,34 @@ convert_na_to.data.frame <- function(x,
     verbose = verbose
   )
 
-  # list are not covered by .select_nse
-  if (length(select_nse) == 0 && is.list(select)) {
-    if (inherits(exclude, "formula")) {
-      exclude <- all.vars(exclude)
+  # default
+  lookup <- lapply(x, function(y) {
+    if (is.numeric(y)) {
+      replace_num
+    } else if (is.character(y)) {
+      replace_char
+    } else if (is.factor(y)) {
+      replace_fac
     }
+  })
 
-    not_modify <- if (is.character(exclude)) {
-      exclude
-    } else if (is.numeric(exclude)) {
-      colnames(x)[exclude]
-    }
-    names_data <- names(x)
-    names_sel <- names(select)
-    apply_default <- names_data[which(!names_data %in% c(names_sel, not_modify))]
+  # override for specific vars
+  try_eval <- try(eval(select), silent = TRUE)
+  select_is_list <- !inherits(try_eval, "try-error") && is.list(select)
 
-    for (i in seq_along(names_sel)) {
-      if (!names_sel[i] %in% names_data) next
-      x[[names_sel[i]]] <- convert_na_to(
-        x[[names_sel[i]]],
-        replacement = select[[i]],
-        verbose = verbose
-      )
+  if (select_is_list) {
+    for (i in select_nse) {
+      lookup[[i]] <- select[[i]]
     }
-
-    for (i in seq_along(apply_default)) {
-      to_convert <- x[[apply_default[i]]]
-      if (is.numeric(to_convert)) {
-        repl <- replace_num
-      } else if (is.character(to_convert)) {
-        repl <- replace_char
-      } else if (is.factor(to_convert)) {
-        repl <- replace_fac
-      }
-      if (!is.null(repl)) {
-        x[[apply_default[i]]] <- convert_na_to(
-          to_convert,
-          replacement = repl,
-          verbose = FALSE
-        )
-      }
-    }
-    return(x)
+  } else {
+    lookup <- lookup[names(lookup) %in% select_nse]
   }
 
+  lookup <- Filter(Negate(is.null), lookup)
 
-  x[select_nse] <- lapply(x[select_nse], function(x) {
-    if (is.numeric(x)) {
-      repl <- replace_num
-    } else if (is.character(x)) {
-      repl <- as.character(replace_char)
-    } else if (is.factor(x)) {
-      repl <- replace_fac
-    }
-    convert_na_to(x, replacement = repl, verbose = FALSE)
-  })
+  for (i in names(lookup)) {
+    x[[i]] <- convert_na_to(x[[i]], replacement = lookup[[i]], verbose = verbose)
+  }
+
   x
 }

--- a/R/convert_na_to.R
+++ b/R/convert_na_to.R
@@ -161,7 +161,8 @@ convert_na_to.data.frame <- function(x,
                                      verbose = TRUE,
                                      ...) {
   data <- x
-  select_nse <- .select_nse(select,
+  select_nse <- .select_nse(
+    select,
     data,
     exclude = exclude,
     ignore_case,
@@ -169,16 +170,17 @@ convert_na_to.data.frame <- function(x,
     verbose = verbose
   )
 
+  .replace_by_type <- function(y) {
+    switch(class(y),
+      "integer" = ,
+      "numeric" = replace_num,
+      "character" = replace_char,
+      "factor" = replace_fac
+    )
+  }
+
   # default
-  lookup <- lapply(x, function(y) {
-    if (is.numeric(y)) {
-      replace_num
-    } else if (is.character(y)) {
-      replace_char
-    } else if (is.factor(y)) {
-      replace_fac
-    }
-  })
+  lookup <- lapply(x, .replace_by_type)
 
   # override for specific vars
   try_eval <- try(eval(select), silent = TRUE)

--- a/R/data_relocate.R
+++ b/R/data_relocate.R
@@ -37,7 +37,6 @@
 #'
 #' # Reorder columns
 #' head(data_reorder(iris, c("Species", "Sepal.Length")))
-#' head(data_reorder(iris, c("Species", "dupa"))) # Safe for non-existing cols
 #'
 #' @export
 data_relocate <- function(data,

--- a/R/data_rotate.R
+++ b/R/data_rotate.R
@@ -31,11 +31,8 @@
 #' data_rotate(x, colnames = TRUE)
 #' data_rotate(x, rownames = "property", colnames = TRUE)
 #'
-#' # warn that data types are changed
-#' str(data_rotate(iris[1:4, ]))
-#'
 #' # use either first column or specific column for column names
-#' x <- data.frame(a = 1:5, b = 11:15, c = letters[1:5], d = rnorm(5))
+#' x <- data.frame(a = 1:5, b = 11:15, c = 21:25)
 #' data_rotate(x, colnames = TRUE)
 #' data_rotate(x, colnames = "c")
 #'

--- a/R/data_to_long.R
+++ b/R/data_to_long.R
@@ -56,7 +56,7 @@
 #'   rows_to = "Participant"
 #' )
 #'
-#' reshape_longer(
+#' data_to_long(
 #'   tidyr::who,
 #'   select = new_sp_m014:newrel_f65,
 #'   names_to = c("diagnosis", "gender", "age"),

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -49,14 +49,14 @@
 #'        4   M     cond2        12.9")
 #'
 #'
-#' reshape_wider(
+#' data_to_wide(
 #'   data_long,
 #'   id_cols = "subject",
 #'   names_from = "condition",
 #'   values_from = "measurement"
 #' )
 #'
-#' reshape_wider(
+#' data_to_wide(
 #'   data_long,
 #'   id_cols = "subject",
 #'   names_from = "condition",
@@ -74,7 +74,7 @@
 #'
 #' production$production <- rnorm(nrow(production))
 #'
-#' reshape_wider(
+#' data_to_wide(
 #'   production,
 #'   names_from = c("product", "country"),
 #'   values_from = "production",

--- a/R/ranktransform.R
+++ b/R/ranktransform.R
@@ -18,7 +18,9 @@
 #'
 #' @examples
 #' ranktransform(c(0, 1, 5, -5, -2))
-#' ranktransform(c(0, 1, 5, -5, -2), sign = TRUE)
+#'
+#' # Won't work
+#' # ranktransform(c(0, 1, 5, -5, -2), sign = TRUE)
 #'
 #' head(ranktransform(trees))
 #' @return A rank-transformed object.

--- a/R/select_nse.R
+++ b/R/select_nse.R
@@ -386,7 +386,7 @@
 
 # e.g list(gear = 4, cyl = 5) [NOT SURE IT WILL BE USED]
 .select_list <- function(expr, data, ignore_case, regex, verbose) {
-  vars <- names(expr)
+  vars <- names(.dynEval(expr, inherits = FALSE, minframe = 0L))
   unlist(lapply(
     vars,
     .eval_expr,

--- a/R/select_nse.R
+++ b/R/select_nse.R
@@ -384,7 +384,7 @@
   ))
 }
 
-# e.g list(gear = 4, cyl = 5) [NOT SURE IT WILL BE USED]
+# e.g list(gear = 4, cyl = 5)
 .select_list <- function(expr, data, ignore_case, regex, verbose) {
   vars <- names(.dynEval(expr, inherits = FALSE, minframe = 0L))
   unlist(lapply(

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -125,7 +125,6 @@ head(data_relocate(iris, select = c("Species", "Petal.Length"), after = 2))
 
 # Reorder columns
 head(data_reorder(iris, c("Species", "Sepal.Length")))
-head(data_reorder(iris, c("Species", "dupa"))) # Safe for non-existing cols
 
 # Remove columns
 head(data_remove(iris, "Sepal.Length"))

--- a/man/data_rotate.Rd
+++ b/man/data_rotate.Rd
@@ -44,11 +44,8 @@ data_rotate(x, rownames = "property")
 data_rotate(x, colnames = TRUE)
 data_rotate(x, rownames = "property", colnames = TRUE)
 
-# warn that data types are changed
-str(data_rotate(iris[1:4, ]))
-
 # use either first column or specific column for column names
-x <- data.frame(a = 1:5, b = 11:15, c = letters[1:5], d = rnorm(5))
+x <- data.frame(a = 1:5, b = 11:15, c = 21:25)
 data_rotate(x, colnames = TRUE)
 data_rotate(x, colnames = "c")
 

--- a/man/data_to_long.Rd
+++ b/man/data_to_long.Rd
@@ -152,7 +152,7 @@ data_to_long(data,
   rows_to = "Participant"
 )
 
-reshape_longer(
+data_to_long(
   tidyr::who,
   select = new_sp_m014:newrel_f65,
   names_to = c("diagnosis", "gender", "age"),

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -101,14 +101,14 @@ data_long <- read.table(header = TRUE, text = "
        4   M     cond2        12.9")
 
 
-reshape_wider(
+data_to_wide(
   data_long,
   id_cols = "subject",
   names_from = "condition",
   values_from = "measurement"
 )
 
-reshape_wider(
+data_to_wide(
   data_long,
   id_cols = "subject",
   names_from = "condition",
@@ -126,7 +126,7 @@ production <- data_filter(production, (product == "A" & country == "AI") | produ
 
 production$production <- rnorm(nrow(production))
 
-reshape_wider(
+data_to_wide(
   production,
   names_from = c("product", "country"),
   values_from = "production",

--- a/man/ranktransform.Rd
+++ b/man/ranktransform.Rd
@@ -106,7 +106,9 @@ from the input data frame.
 
 \examples{
 ranktransform(c(0, 1, 5, -5, -2))
-ranktransform(c(0, 1, 5, -5, -2), sign = TRUE)
+
+# Won't work
+# ranktransform(c(0, 1, 5, -5, -2), sign = TRUE)
 
 head(ranktransform(trees))
 }

--- a/tests/testthat/test-convert_na_to.R
+++ b/tests/testthat/test-convert_na_to.R
@@ -1,14 +1,17 @@
 # numeric --------------------------
 
 test_that("convert_na_to - numeric: works", {
-  expect_equal(
+  expect_identical(
     convert_na_to(c(1, 2, 3, NA), replacement = 4),
-    1:4
+    as.double(1:4)
   )
 
-  expect_equal(
-    convert_na_to(c(1, 2, 3, NA), replacement = NULL, verbose = FALSE),
-    c(1, 2, 3, NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c(1, 2, 3, NA), replacement = NULL),
+      c(1, 2, 3, NA)
+    ),
+    "needs to be a numeric"
   )
 })
 
@@ -32,13 +35,19 @@ test_that("convert_na_to - numeric: arg 'replacement' must be of length one", {
 
 
 test_that("convert_na_to - numeric: returns original vector if 'replacement' not good", {
-  expect_equal(
-    convert_na_to(c(1, 2, 3, NA), replacement = "a", verbose = FALSE),
-    c(1, 2, 3, NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c(1, 2, 3, NA), replacement = "a"),
+      c(1, 2, 3, NA)
+    ),
+    "needs to be a numeric"
   )
-  expect_equal(
-    convert_na_to(c(1, 2, 3, NA), replacement = factor(8), verbose = FALSE),
-    c(1, 2, 3, NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c(1, 2, 3, NA), replacement = factor(8)),
+      c(1, 2, 3, NA)
+    ),
+    "needs to be a numeric"
   )
 })
 
@@ -47,13 +56,16 @@ test_that("convert_na_to - numeric: returns original vector if 'replacement' not
 # character --------------------------
 
 test_that("convert_na_to - character: works", {
-  expect_equal(
+  expect_identical(
     convert_na_to(c("a", "b", "c", NA), replacement = "d"),
     c("a", "b", "c", "d")
   )
-  expect_equal(
-    convert_na_to(c("a", "b", "c", NA), replacement = NULL, verbose = FALSE),
-    c("a", "b", "c", NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c("a", "b", "c", NA), replacement = NULL),
+      c("a", "b", "c", NA)
+    ),
+    "needs to be a character"
   )
 })
 
@@ -76,17 +88,23 @@ test_that("convert_na_to - numeric: arg 'replacement' must be of length one", {
 })
 
 test_that("convert_na_to - character: returns original vector if 'replacement' not good", {
-  expect_equal(
-    convert_na_to(c("a", "b", "c", NA), replacement = 1, verbose = FALSE),
+  expect_identical(
+    convert_na_to(c("a", "b", "c", NA), replacement = 1),
     c("a", "b", "c", 1)
   )
-  expect_equal(
-    convert_na_to(c("a", "b", "c", NA), replacement = mtcars, verbose = FALSE),
-    c("a", "b", "c", NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c("a", "b", "c", NA), replacement = mtcars),
+      c("a", "b", "c", NA)
+    ),
+    "needs to be a character or numeric vector"
   )
-  expect_equal(
-    convert_na_to(c("a", "b", "c", NA), replacement = factor(8), verbose = FALSE),
-    c("a", "b", "c", NA)
+  expect_warning(
+    expect_identical(
+      convert_na_to(c("a", "b", "c", NA), replacement = factor(8)),
+      c("a", "b", "c", NA)
+    ),
+    "needs to be a character or numeric vector"
   )
 })
 
@@ -98,24 +116,27 @@ test_that("convert_na_to - character: returns original vector if 'replacement' n
 
 test_that("convert_na_to - factor: works when 'replacement' is numeric ", {
   x <- convert_na_to(factor(c(1, 2, 3, NA)), replacement = 4)
-  expect_equal(
+  expect_identical(
     x,
     factor(1:4)
   )
-  expect_equal(levels(x), as.character(1:4))
-  expect_equal(
-    convert_na_to(factor(c(1, 2, 3, NA)), replacement = NULL, verbose = FALSE),
-    factor(c(1, 2, 3, NA))
+  expect_identical(levels(x), as.character(1:4))
+  expect_warning(
+    expect_identical(
+      convert_na_to(factor(c(1, 2, 3, NA)), replacement = NULL),
+      factor(c(1, 2, 3, NA))
+    ),
+    "needs to be of length one"
   )
 })
 
 test_that("convert_na_to - factor: works when 'replacement' is character", {
   x <- convert_na_to(factor(c(1, 2, 3, NA)), replacement = "d")
-  expect_equal(
+  expect_identical(
     x,
     factor(c(1:3, "d"))
   )
-  expect_equal(levels(x), as.character(c(1:3, "d")))
+  expect_identical(levels(x), as.character(c(1:3, "d")))
 })
 
 
@@ -135,7 +156,7 @@ test <- data.frame(
 )
 
 test_that("convert_na_to - data frame: works with replace_* args", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test, replace_num = 4, replace_char = "e", replace_fac = 8),
     data.frame(
       x = c(1, 2, 4),
@@ -148,7 +169,7 @@ test_that("convert_na_to - data frame: works with replace_* args", {
 })
 
 test_that("convert_na_to - data frame: only modifies numeric if only numeric specified", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test, replace_num = 4),
     data.frame(
       x = c(1, 2, 4),
@@ -161,7 +182,7 @@ test_that("convert_na_to - data frame: only modifies numeric if only numeric spe
 })
 
 test_that("convert_na_to - data frame: only modifies character if only character specified", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test, replace_char = "e"),
     data.frame(
       x = c(1, 2, NA),
@@ -174,7 +195,7 @@ test_that("convert_na_to - data frame: only modifies character if only character
 })
 
 test_that("convert_na_to - data frame: only modifies factor if only factor specified", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test, replace_fac = 8),
     data.frame(
       x = c(1, 2, NA),
@@ -187,7 +208,7 @@ test_that("convert_na_to - data frame: only modifies factor if only factor speci
 })
 
 test_that("convert_na_to - data frame: arg 'select' works", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = "x"
@@ -201,7 +222,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = ~x
@@ -215,7 +236,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = starts_with("x")
@@ -229,7 +250,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = ends_with("2")
@@ -243,7 +264,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = contains("x")
@@ -257,7 +278,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = 1:3
@@ -271,7 +292,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = regex("2$")
@@ -288,7 +309,7 @@ test_that("convert_na_to - data frame: arg 'select' works", {
 
 
 test_that("convert_na_to - data frame: arg 'exclude' works", {
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, exclude = "x"
@@ -302,7 +323,7 @@ test_that("convert_na_to - data frame: arg 'exclude' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, exclude = ~x
@@ -316,7 +337,7 @@ test_that("convert_na_to - data frame: arg 'exclude' works", {
     )
   )
 
-  expect_equal(
+  expect_identical(
     convert_na_to(test,
       replace_num = 4, replace_char = "e",
       replace_fac = 8, select = starts_with("x"), exclude = ~x
@@ -331,66 +352,69 @@ test_that("convert_na_to - data frame: arg 'exclude' works", {
   )
 })
 
-# test_that("convert_na_to - data frame: works when arg 'select' is a list", {
-#   # numeric
-#   expect_equal(
-#     convert_na_to(test, replace_num = 4, select = list(x = 0), verbose = FALSE),
-#     data.frame(
-#       x = c(1, 2, 0),
-#       y = c("a", "b", NA),
-#       z = factor(c("a", "b", NA)),
-#       x2 = c(4, 5, 4),
-#       stringsAsFactors = FALSE
-#     )
-#   )
-#
-#   # character
-#   expect_equal(
-#     convert_na_to(test, replace_char = "e", select = list(y = "d"), verbose = FALSE),
-#     data.frame(
-#       x = c(1, 2, NA),
-#       y = c("a", "b", "d"),
-#       z = factor(c("a", "b", NA)),
-#       x2 = c(4, 5, NA),
-#       stringsAsFactors = FALSE
-#     )
-#   )
-#
-#   # only named list can override replace_*
-#   expect_equal(
-#     convert_na_to(test, replace_num = 4, select = list(0), verbose = FALSE),
-#     data.frame(
-#       x = c(1, 2, 4),
-#       y = c("a", "b", NA),
-#       z = factor(c("a", "b", NA)),
-#       x2 = c(4, 5, 4),
-#       stringsAsFactors = FALSE
-#     )
-#   )
-#
-#   expect_equal(
-#     convert_na_to(test, replace_char = "e", select = list("d"), verbose = FALSE),
-#     data.frame(
-#       x = c(1, 2, NA),
-#       y = c("a", "b", "e"),
-#       z = factor(c("a", "b", NA)),
-#       x2 = c(4, 5, NA),
-#       stringsAsFactors = FALSE
-#     )
-#   )
-#
-#   # no problem if put a variable that doesn't exist in list
-#   expect_equal(
-#     convert_na_to(test, replace_num = 4, select = list(x = 0, foo = 5), verbose = FALSE),
-#     data.frame(
-#       x = c(1, 2, 0),
-#       y = c("a", "b", NA),
-#       z = factor(c("a", "b", NA)),
-#       x2 = c(4, 5, 4),
-#       stringsAsFactors = FALSE
-#     )
-#   )
-# })
+test_that("convert_na_to - data frame: works when arg 'select' is a list", {
+  # numeric
+  expect_identical(
+    convert_na_to(test, replace_num = 4, select = list(x = 0)),
+    data.frame(
+      x = c(1, 2, 0),
+      y = c("a", "b", NA),
+      z = factor(c("a", "b", NA)),
+      x2 = c(4, 5, 4),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  # character
+  expect_identical(
+    convert_na_to(test, replace_char = "e", select = list(y = "d")),
+    data.frame(
+      x = c(1, 2, NA),
+      y = c("a", "b", "d"),
+      z = factor(c("a", "b", NA)),
+      x2 = c(4, 5, NA),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  # only named list can override replace_*
+  expect_identical(
+    convert_na_to(test, replace_num = 4, select = list(0)),
+    data.frame(
+      x = c(1, 2, 4),
+      y = c("a", "b", NA),
+      z = factor(c("a", "b", NA)),
+      x2 = c(4, 5, 4),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  expect_identical(
+    convert_na_to(test, replace_char = "e", select = list("d")),
+    data.frame(
+      x = c(1, 2, NA),
+      y = c("a", "b", "e"),
+      z = factor(c("a", "b", NA)),
+      x2 = c(4, 5, NA),
+      stringsAsFactors = FALSE
+    )
+  )
+
+  # no problem if put a variable that doesn't exist in list
+  expect_warning(
+    expect_identical(
+      convert_na_to(test, replace_num = 4, select = list(x = 0, foo = 5)),
+      data.frame(
+        x = c(1, 2, 0),
+        y = c("a", "b", NA),
+        z = factor(c("a", "b", NA)),
+        x2 = c(4, 5, 4),
+        stringsAsFactors = FALSE
+      )
+    ),
+    "not found"
+  )
+})
 
 
 
@@ -406,16 +430,16 @@ test_that("data_rename preserves attributes", {
   out2 <- convert_na_to(out, replace_num = 5)
   a2 <- attributes(out2)
 
-  expect_equal(names(a1)[1:28], names(a2)[1:28])
+  expect_identical(names(a1)[1:28], names(a2)[1:28])
 })
 
 # select helpers ------------------------------
 test_that("convert_na_to regex", {
-  expect_equal(
+  expect_identical(
     convert_na_to(airquality, replacement = 0, select = "zone", regex = TRUE),
     convert_na_to(airquality, replacement = 0, select = "Ozone")
   )
-  expect_equal(
+  expect_identical(
     convert_na_to(airquality, replacement = 0, select = "zone$", regex = TRUE),
     convert_na_to(airquality, replacement = 0, select = "Ozone")
   )

--- a/tests/testthat/test-standardize_models.R
+++ b/tests/testthat/test-standardize_models.R
@@ -82,7 +82,7 @@ test_that("weights", {
   m <- lm(mpg ~ wt + hp, weights = cyl, mtcars)
 
   sm <<- standardize(m, weights = TRUE)
-  sm_data <- insight::get_data(sm)
+  sm_data <- insight::get_data(sm, source = "frame")
   sm_data2 <- standardize(mtcars, select = c("mpg", "wt", "hp"), weights = "cyl")
   expect_equal(sm_data[, c("mpg", "wt", "hp")], sm_data2[, c("mpg", "wt", "hp")])
 
@@ -90,7 +90,7 @@ test_that("weights", {
 
   # no weights in stding
   sm_xw <<- standardize(m, weights = FALSE)
-  sm_data_xw <- insight::get_data(sm_xw)
+  sm_data_xw <- insight::get_data(sm_xw, source = "frame")
   expect_false(isTRUE(all.equal(coef(sm)[-1], coef(sm_xw)[-1])))
 
   skip_if_not_installed("effectsize")

--- a/tests/testthat/test-standardize_models.R
+++ b/tests/testthat/test-standardize_models.R
@@ -6,7 +6,7 @@ test_that("standardize.lm", {
   m0 <- lm(Sepal.Length ~ Species * Petal.Width, data = iris_z)
   m1 <- lm(Sepal.Length ~ Species * Petal.Width, data = iris2)
   model <- standardize(m1)
-  expect_equal(coef(m0), coef(model))
+  expect_identical(coef(m0), coef(model))
 })
 
 test_that("standardize, mlm", {
@@ -14,7 +14,7 @@ test_that("standardize, mlm", {
   m2 <- lm(scale(cbind(mpg, hp)) ~ scale(cyl) + scale(am), data = mtcars)
 
   mz <- standardize(m)
-  expect_equal(coef(mz), coef(m2), ignore_attr = TRUE)
+  expect_identical(coef(mz), coef(m2), ignore_attr = TRUE)
 })
 
 test_that("standardize | errors", {
@@ -65,7 +65,7 @@ test_that("transformations", {
 
 
   expect_message(out <- standardize(m))
-  expect_equal(coef(m), c(
+  expect_identical(coef(m), c(
     `(Intercept)` = -0.4575, `as.numeric(time)` = 0.5492, group = 0.3379,
     `as.numeric(time):group` = 0.15779
   ), tolerance = 0.01)
@@ -84,7 +84,7 @@ test_that("weights", {
   sm <<- standardize(m, weights = TRUE)
   sm_data <- insight::get_data(sm, source = "frame")
   sm_data2 <- standardize(mtcars, select = c("mpg", "wt", "hp"), weights = "cyl")
-  expect_equal(sm_data[, c("mpg", "wt", "hp")], sm_data2[, c("mpg", "wt", "hp")])
+  expect_identical(sm_data[, c("mpg", "wt", "hp")], sm_data2[, c("mpg", "wt", "hp")])
 
   expect_error(standardize(m, weights = TRUE, robust = TRUE), NA)
 
@@ -137,12 +137,12 @@ test_that("weights + NA", {
   # weights, missing data, but data isn't weight-stdized
   m2 <- lm(Sepal.Length ~ Species + Petal.Width, data = iris2, weights = weight_me)
   sm2 <- standardize(m1, weights = FALSE)
-  expect_equal(coef(m2), coef(sm2))
+  expect_identical(coef(m2), coef(sm2))
 
   # weights, missing data, and data is weight-stdized
   m3 <- lm(Sepal.Length ~ Species + Petal.Width, data = iris3, weights = weight_me)
   sm3 <- standardize(m1, weights = TRUE)
-  expect_equal(coef(m3), coef(sm3))
+  expect_identical(coef(m3), coef(sm3))
 })
 
 
@@ -161,8 +161,8 @@ test_that("weights + NA + na.exclude", {
   m1 <- lm(Sepal.Length ~ Species + Petal.Width, data = d, weights = weight_me, na.action = na.exclude)
   m2 <- lm(Sepal.Length ~ Species + Petal.Width, data = d, weights = weight_me)
 
-  expect_equal(coef(standardize(m2)), coef(standardize(m1)), tolerance = 1e-3)
-  expect_equal(effectsize::standardize_parameters(m1, method = "basic")[[2]],
+  expect_identical(coef(standardize(m2)), coef(standardize(m1)), tolerance = 1e-3)
+  expect_identical(effectsize::standardize_parameters(m1, method = "basic")[[2]],
     effectsize::standardize_parameters(m2, method = "basic")[[2]],
     tolerance = 1e-3
   )
@@ -192,9 +192,9 @@ test_that("standardize non-Gaussian response", {
   m2 <- glm(Reaction ~ Days, family = Gamma(link = "identity"), data = sleepstudy)
   m3 <- glm(Reaction ~ Days, family = inverse.gaussian(), data = sleepstudy)
 
-  expect_equal(coef(standardize(m1)), c(`(Intercept)` = 0.00338, Days = -0.00034), tolerance = 1e-2)
-  expect_equal(coef(standardize(m2)), c(`(Intercept)` = 298.48571, Days = 29.70754), tolerance = 1e-3)
-  expect_equal(coef(standardize(m3)), c(`(Intercept)` = 1e-05, Days = 0), tolerance = 1e-3)
+  expect_identical(coef(standardize(m1)), c(`(Intercept)` = 0.00338, Days = -0.00034), tolerance = 1e-2)
+  expect_identical(coef(standardize(m2)), c(`(Intercept)` = 298.48571, Days = 29.70754), tolerance = 1e-3)
+  expect_identical(coef(standardize(m3)), c(`(Intercept)` = 1e-05, Days = 0), tolerance = 1e-3)
 })
 
 
@@ -233,7 +233,7 @@ test_that("standardize mediation", {
 
   out1 <- summary(standardize(med1))
   expect_message(out2 <- summary(standardize(med2)))
-  expect_equal(unlist(out1[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
+  expect_identical(unlist(out1[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
     unlist(out2[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
     tolerance = 0.1
   )
@@ -254,7 +254,7 @@ test_that("standardize mediation", {
     mediator = "job_seek"
   ))
   outz <- summary(medz)
-  expect_equal(unlist(out0[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
+  expect_identical(unlist(out0[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
     unlist(outz[c("d0", "d1", "z0", "z1", "n0", "n1", "tau.coef")]),
     tolerance = 0.1
   )
@@ -270,7 +270,7 @@ test_that("offsets", {
 
   expect_warning(mz1 <- standardize(m))
   expect_warning(mz2 <- standardize(m, two_sd = TRUE))
-  expect_equal(c(1, 2) * coef(mz1), coef(mz2))
+  expect_identical(c(1, 2) * coef(mz1), coef(mz2))
 
 
   m <- glm(cyl ~ hp + offset(wt), family = poisson(), data = mtcars)
@@ -278,7 +278,7 @@ test_that("offsets", {
 
   par1 <- parameters::model_parameters(mz)
   par2 <- effectsize::standardize_parameters(m, method = "basic")
-  expect_equal(par2[2, 2], par1[2, 2], tolerance = 0.05)
+  expect_identical(par2[2, 2], par1[2, 2], tolerance = 0.05)
 })
 
 


### PR DESCRIPTION
Close #352 . 

The code of `convert_na_to.data.frame()` is now much simpler. This also fixes an unexpected warning about unknown variables.

``` r
library(datawizard)

test_df <- data.frame(
  x = c(1, 2, NA),
  x2 = c(4, 5, NA),
  y = c("a", "b", NA)
)
test_df
#>    x x2    y
#> 1  1  4    a
#> 2  2  5    b
#> 3 NA NA <NA>

convert_na_to(
  test_df,
  replace_num = 0,
  select = list(x2 = 1)
)
#>   x x2    y
#> 1 1  4    a
#> 2 2  5    b
#> 3 0  1 <NA>
```