### PR TITLE
dw_transformer hits again

### DIFF
--- a/R/center.R
+++ b/R/center.R
@@ -119,6 +119,7 @@ center.numeric <- function(x,
   }
 
   args <- .process_std_center(x, weights, robust, verbose, reference, center, scale = NULL)
+  dot_args <- list(...)
 
   if (is.null(args)) {
     # all NA?

--- a/R/center.R
+++ b/R/center.R
@@ -136,7 +136,10 @@ center.numeric <- function(x,
   attr(centered_x, "robust") <- robust
   # labels
   z <- .set_back_labels(centered_x, x, include_values = FALSE)
-  class(z) <- c("dw_transformer", class(z))
+  # don't add attribute when we call data frame methods
+  if (!isFALSE(dot_args$add_transform_class)) {
+    class(z) <- c("dw_transformer", class(z))
+  }
   z
 }
 
@@ -209,7 +212,8 @@ center.data.frame <- function(x,
       verbose = FALSE,
       reference = reference[[var]],
       center = args$center[var],
-      force = force
+      force = force,
+      add_transform_class = FALSE
     )
   }
 
@@ -262,6 +266,7 @@ center.grouped_df <- function(x,
       force = force,
       append = FALSE,
       center = center,
+      add_transform_class = FALSE,
       ...
     )
   }

--- a/R/data_rescale.R
+++ b/R/data_rescale.R
@@ -130,7 +130,10 @@ rescale.numeric <- function(x,
   attr(out, "new_max") <- new_max
   attr(out, "range_difference") <- max_value - min_value
   attr(out, "to_range") <- c(new_min, new_max)
-  class(out) <- c("dw_transformer", class(out))
+  # don't add attribute when we call data frame methods
+  if (!isFALSE(dot_args$add_transform_class)) {
+    class(out) <- c("dw_transformer", class(out))
+  }
 
   out
 }
@@ -168,6 +171,7 @@ rescale.grouped_df <- function(x,
       exclude = exclude,
       to = to,
       range = range,
+      add_transform_class = FALSE,
       ...
     )
   }
@@ -208,7 +212,7 @@ rescale.data.frame <- function(x,
   }
 
   x[select] <- as.data.frame(sapply(select, function(n) {
-    rescale(x[[n]], to = to[[n]], range = range[[n]])
+    rescale(x[[n]], to = to[[n]], range = range[[n]], add_transform_class = FALSE)
   }, simplify = FALSE))
   x
 }

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -159,7 +159,10 @@ normalize.numeric <- function(x, include_bounds = TRUE, verbose = TRUE, ...) {
   attr(out, "min_value") <- min_value
   attr(out, "vector_length") <- vector_length
   attr(out, "range_difference") <- range_difference
-  class(out) <- c("dw_transformer", class(out))
+  # don't add attribute when we call data frame methods
+  if (!isFALSE(dot_args$add_transform_class)) {
+    class(out) <- c("dw_transformer", class(out))
+  }
 
   out
 }
@@ -209,6 +212,7 @@ normalize.grouped_df <- function(x,
       exclude = exclude,
       include_bounds = include_bounds,
       verbose = verbose,
+      add_transform_class = FALSE,
       ...
     )
   }
@@ -241,7 +245,8 @@ normalize.data.frame <- function(x,
     x[select],
     normalize,
     include_bounds = include_bounds,
-    verbose = verbose
+    verbose = verbose,
+    add_transform_class = FALSE
   )
 
   x

--- a/R/standardize.R
+++ b/R/standardize.R
@@ -161,6 +161,7 @@ standardize.numeric <- function(x,
   }
 
   args <- .process_std_center(x, weights, robust, verbose, reference, center, scale)
+  dot_args <- list(...)
 
   # Perform standardization
   if (is.null(args)) {
@@ -183,7 +184,9 @@ standardize.numeric <- function(x,
   attr(scaled_x, "robust") <- robust
   # labels
   z <- .set_back_labels(scaled_x, x, include_values = FALSE)
-  class(z) <- c("dw_transformer", class(z))
+  if (!isFALSE(dot_args$add_transform_class)) {
+    class(z) <- c("dw_transformer", class(z))
+  }
   z
 }
 
@@ -292,7 +295,8 @@ standardize.data.frame <- function(x,
       center = args$center[var],
       scale = args$scale[var],
       verbose = FALSE,
-      force = force
+      force = force,
+      add_transform_class = FALSE
     )
   }
 
@@ -350,6 +354,7 @@ standardize.grouped_df <- function(x,
       append = FALSE,
       center = center,
       scale = scale,
+      add_transform_class = FALSE,
       ...
     )
   }

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -156,13 +156,15 @@ test_that("center, factors (grouped data)", {
 
 # select helpers ------------------------------
 test_that("center regex", {
-  expect_identical(
+  expect_equal(
     center(mtcars, select = "pg", regex = TRUE)$mpg,
-    center(mtcars$mpg)
+    center(mtcars$mpg),
+    ignore_attr = TRUE
   )
-  expect_identical(
+  expect_equal(
     center(mtcars, select = "pg$", regex = TRUE)$mpg,
-    center(mtcars$mpg)
+    center(mtcars$mpg),
+    ignore_attr = TRUE
   )
 })
 

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -41,6 +41,14 @@ test_that("center, force factors", {
     tolerance = 1e-4,
     ignore_attr = TRUE
   )
+  # check class attributes
+  expect_identical(
+    vapply(z, class, character(1)),
+    c(
+      Sepal.Length = "numeric", Sepal.Width = "numeric", Petal.Length = "numeric",
+      Petal.Width = "numeric", Species = "factor"
+    )
+  )
 })
 
 test_that("center, all na", {

--- a/tests/testthat/test-center.R
+++ b/tests/testthat/test-center.R
@@ -26,6 +26,14 @@ test_that("center, select", {
     tolerance = 1e-4,
     ignore_attr = TRUE
   )
+  # check class attributes
+  expect_identical(
+    vapply(z, class, character(1)),
+    c(
+      Sepal.Length = "numeric", Sepal.Width = "numeric", Petal.Length = "numeric",
+      Petal.Width = "numeric", Species = "factor"
+    )
+  )
 })
 
 test_that("center, factors", {
@@ -40,14 +48,6 @@ test_that("center, force factors", {
     v - median(v),
     tolerance = 1e-4,
     ignore_attr = TRUE
-  )
-  # check class attributes
-  expect_identical(
-    vapply(z, class, character(1)),
-    c(
-      Sepal.Length = "numeric", Sepal.Width = "numeric", Petal.Length = "numeric",
-      Petal.Width = "numeric", Species = "factor"
-    )
   )
 })
 

--- a/tests/testthat/test-data_rescale.R
+++ b/tests/testthat/test-data_rescale.R
@@ -50,6 +50,15 @@ test_that("rescale works with select helpers", {
   expect_equal(head(out$Sepal.Width), c(0.625, 0.41667, 0.5, 0.45833, 0.66667, 0.79167), tolerance = 1e-3)
   expect_equal(head(out$Petal.Length), head(iris$Petal.Length), tolerance = 1e-3)
 
+  # check class attributes
+  expect_identical(
+    vapply(out, class, character(1)),
+    c(
+      Sepal.Length = "numeric", Sepal.Width = "numeric", Petal.Length = "numeric",
+      Petal.Width = "numeric", Species = "factor"
+    )
+  )
+
   out <- rescale(iris, to = c(0, 1), select = starts_with("Sepal"))
   expect_equal(head(out$Sepal.Width), c(0.625, 0.41667, 0.5, 0.45833, 0.66667, 0.79167), tolerance = 1e-3)
   expect_equal(head(out$Petal.Length), head(iris$Petal.Length), tolerance = 1e-3)
@@ -66,6 +75,7 @@ test_that("rescale works with select helpers", {
 test_that("data_rescale regex", {
   expect_equal(
     rescale(mtcars, select = "pg", regex = TRUE)$mpg,
-    rescale(mtcars, select = "mpg")$mpg
+    rescale(mtcars, select = "mpg")$mpg,
+    ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test-normalize.R
+++ b/tests/testthat/test-normalize.R
@@ -83,7 +83,9 @@ test_that("normalize: only one value", {
     regexp = "Variable `foo` contains only one unique value and will"
   )
   expect_warning(
-    y <- normalize(x = 12),
+    {
+      y <- normalize(x = 12)
+    },
     regexp = "Variable `12` contains only one unique value and will"
   )
   expect_equal(y, 12, ignore_attr = TRUE)
@@ -93,9 +95,9 @@ test_that("normalize: only one value", {
 })
 
 test_that("normalize: only two values", {
-  expect_warning(
+  expect_warning({
     y <- normalize(x = c(1, 2))
-  )
+  })
   expect_equal(y, c(0, 1), ignore_attr = TRUE)
 
   expect_silent(normalize(x = c(1, 2), verbose = FALSE))
@@ -120,13 +122,14 @@ test_that("normalize: matrix", {
 test_that("normalize: select", {
   skip_if_not_installed("poorman")
 
-  expect_identical(
+  expect_equal(
     normalize(
       iris,
       select = starts_with("Petal\\.L")
     ) %>%
       poorman::pull(Petal.Length),
-    normalize(iris$Petal.Length)
+    normalize(iris$Petal.Length),
+    ignore_attr = TRUE
   )
 })
 

--- a/tests/testthat/test-standardize-data.R
+++ b/tests/testthat/test-standardize-data.R
@@ -42,6 +42,15 @@ test_that("standardize.data.frame", {
   expect_length(levels(x$Species), 3)
   expect_equal(mean(subset(x, Species == "virginica")$Sepal.Length), 0.90, tolerance = 0.01)
 
+  # check class attributes
+  expect_identical(
+    vapply(x, class, character(1)),
+    c(
+      Sepal.Length = "numeric", Sepal.Width = "numeric", Petal.Length = "numeric",
+      Petal.Width = "numeric", Species = "factor"
+    )
+  )
+
   x2 <- standardize(x = iris[1, ], reference = iris)
   expect_true(all(x2[1, ] == x[1, ]))
 

--- a/tests/testthat/test-standardize-data.R
+++ b/tests/testthat/test-standardize-data.R
@@ -131,7 +131,8 @@ test_that("standardize.data.frame, weights", {
   expect_equal(
     standardize(x, weights = w),
     standardize(data.frame(x), weights = w)$x,
-    tolerance = 1e-4
+    tolerance = 1e-4,
+    ignore_attr = TRUE
   )
 
   # name and vector give same results


### PR DESCRIPTION
#408

This PR doesn't fix 408, but we don't need the class attribute for data frame methods, so we can remove it and thereby reduce possible issues we do not yet anticpate.