### PR TITLE
Fix error in dataframe method of `describe_distribution()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.7.1.6
+Version: 0.7.1.7
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,10 @@ BUG FIXES
 
 * `center()` and `standardize()` did not work for grouped data frames (of class
   `grouped_df`) when `force = TRUE`.
+  
+* The `data.frame` method of `describe_distribution()` returns `NULL` instead of
+  an error if no valid variable were passed (for example a factor variable with
+  `include_factors = FALSE`) (#421).
 
 # datawizard 0.7.1
 

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -408,6 +408,8 @@ describe_distribution.data.frame <- function(x,
     }
   }))
 
+  if (is.null(out)) return(NULL)
+
   out$Variable <- row.names(out)
   row.names(out) <- NULL
   out <- out[c("Variable", setdiff(colnames(out), "Variable"))]

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -217,6 +217,11 @@ test_that("describe_distribution - select", {
 
   expect_equal(out$Variable, c("Petal.Length", "Petal.Width"))
   expect_equal(out$Mean, c(3.758000, 1.199333), tolerance = 1e-3)
+
+  expect_null(describe_distribution(iris, select = "Species"))
+  out <- describe_distribution(iris, select = "Species", include_factors = TRUE)
+  exp <- describe_distribution(iris$Species)
+  expect_identical(out$Range, exp$Range)
 })
 
 


### PR DESCRIPTION
Close #421 

``` r
library(datawizard)

describe_distribution(iris$Species)
#> Mean | SD |               Range | Skewness | Kurtosis |   n | n_Missing
#> -----------------------------------------------------------------------
#>      |    | [setosa, virginica] |        0 |    -1.51 | 150 |         0

describe_distribution(iris, select = "Species")
#> NULL
```


