### PR TITLE
Test macos failure

### DIFF
--- a/tests/testthat/test-standardize_models.R
+++ b/tests/testthat/test-standardize_models.R
@@ -286,7 +286,7 @@ test_that("offsets", {
 
 test_that("brms", {
   skip_on_cran()
-  skip_on_os("windows")
+  skip_on_os(c("windows", "mac"))
   skip_if_not_installed("brms")
 
   invisible(


### PR DESCRIPTION
Close #425 

For some reason, this `brms` test fails on macOS. Maybe this could be reported to the `brms` repo but I can't do it (I don't have macOS)