### PR TITLE
recode_into can skip overwriting former recodes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.8.0.1
+Version: 0.8.0.2
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # datawizard (devel)
 
+CHANGES
+
+* `recode_into()` gains an `overwrite` argument to skip overwriting already
+  recoded cases when multiple recode patterns apply to the same case.
+
 BUG FIXES
 
 * Fixed issues in `data_write()` when writing labelled data into SPSS format

--- a/R/recode_into.r
+++ b/R/recode_into.r
@@ -141,7 +141,6 @@ recode_into <- function(..., data = NULL, default = NA, overwrite = TRUE, verbos
     # if user doesn't want to overwrite, remove already recoded indices
     if (!overwrite) {
       index[which(index)[already_exists]] <- FALSE
-      # index <- index[which(index)[!already_exists]]
     }
     out[index] <- value
   }

--- a/R/recode_into.r
+++ b/R/recode_into.r
@@ -15,6 +15,11 @@
 #' @param default Indicates the default value that is chosen when no match in
 #' the formulas in `...` is found. If not provided, `NA` is used as default
 #' value.
+#' @param overwrite Logical, if `TRUE` (default) and more than one recode pattern
+#' apply to the same case, already recoded values will be overwritten by subsequent
+#' recode patterns. If `FALSE`, former recoded cases will not be altered by later
+#' recode patterns that would apply to those cases again. A warning message is
+#' printed to alert such situations and to avoid unintentional recodings.
 #' @param verbose Toggle warnings.
 #'
 #' @return A vector with recoded values.
@@ -49,7 +54,7 @@
 #'   default = 0
 #' )
 #' @export
-recode_into <- function(..., data = NULL, default = NA, verbose = TRUE) {
+recode_into <- function(..., data = NULL, default = NA, overwrite = TRUE, verbose = TRUE) {
   dots <- list(...)
 
   # get length of vector, so we know the length of the output vector
@@ -118,14 +123,24 @@ recode_into <- function(..., data = NULL, default = NA, verbose = TRUE) {
       already_exists <- out[index] != default
     }
     if (any(already_exists) && verbose) {
-      insight::format_warning(
-        paste(
+      if (overwrite) {
+        msg <- paste(
           "Several recode patterns apply to the same cases.",
           "Some of the already recoded cases will be overwritten with new values again",
           sprintf("(e.g. pattern %i overwrites the former recode of case %i).", i, which(already_exists)[1])
-        ),
-        "Please check if this is intentional!"
-      )
+        )
+      } else {
+        msg <- paste(
+          "Several recode patterns apply to the same cases.",
+          "Some of the already recoded cases will not be altered by later recode patterns.",
+          sprintf("(e.g. pattern %i also matches the former recode of case %i).", i, which(already_exists)[1])
+        )
+      }
+      insight::format_warning(msg, "Please check if this is intentional!")
+    }
+    # if user doesn't want to overwrite, remove already recoded indices
+    if (!overwrite) {
+      index <- index[!already_exists]
     }
     out[index] <- value
   }

--- a/R/recode_into.r
+++ b/R/recode_into.r
@@ -140,7 +140,8 @@ recode_into <- function(..., data = NULL, default = NA, overwrite = TRUE, verbos
     }
     # if user doesn't want to overwrite, remove already recoded indices
     if (!overwrite) {
-      index <- index[!already_exists]
+      index[which(index)[already_exists]] <- FALSE
+      # index <- index[which(index)[!already_exists]]
     }
     out[index] <- value
   }

--- a/man/recode_into.Rd
+++ b/man/recode_into.Rd
@@ -4,7 +4,7 @@
 \alias{recode_into}
 \title{Recode values from one or more variables into a new variable}
 \usage{
-recode_into(..., data = NULL, default = NA, verbose = TRUE)
+recode_into(..., data = NULL, default = NA, overwrite = TRUE, verbose = TRUE)
 }
 \arguments{
 \item{...}{A sequence of two-sided formulas, where the left hand side (LHS)
@@ -18,6 +18,12 @@ the data name multiple times in \code{...}. See 'Examples'.}
 \item{default}{Indicates the default value that is chosen when no match in
 the formulas in \code{...} is found. If not provided, \code{NA} is used as default
 value.}
+
+\item{overwrite}{Logical, if \code{TRUE} (default) and more than one recode pattern
+apply to the same case, already recoded values will be overwritten by subsequent
+recode patterns. If \code{FALSE}, former recoded cases will not be altered by later
+recode patterns that would apply to those cases again. A warning message is
+printed to alert such situations and to avoid unintentional recodings.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/tests/testthat/test-recode_into.R
+++ b/tests/testthat/test-recode_into.R
@@ -19,6 +19,29 @@ test_that("recode_into, overwrite", {
     ),
     regex = "overwritten"
   )
+  # validate results
+  x <- 1:10
+  expect_silent({
+    out <- recode_into(
+      x >= 3 & x <= 7 ~ 1,
+      x > 5 ~ 2,
+      default = 0,
+      verbose = FALSE
+    )
+  })
+  expect_identical(out, c(0, 0, 1, 1, 1, 2, 2, 2, 2, 2))
+
+  x <- 1:10
+  expect_silent({
+    out <- recode_into(
+      x >= 3 & x <= 7 ~ 1,
+      x > 5 ~ 2,
+      default = 0,
+      overwrite = FALSE,
+      verbose = FALSE
+    )
+  })
+  expect_identical(out, c(0, 0, 1, 1, 1, 1, 1, 2, 2, 2))
 })
 
 test_that("recode_into, don't overwrite", {

--- a/tests/testthat/test-recode_into.R
+++ b/tests/testthat/test-recode_into.R
@@ -8,6 +8,30 @@ test_that("recode_into", {
   expect_identical(out, c("c", "c", "b", "b", "b", "a", "a", "a", "a", "a"))
 })
 
+test_that("recode_into, overwrite", {
+  expect_warning(
+    recode_into(
+      x > 1 ~ "a",
+      x > 10 & x <= 15 ~ "b",
+      default = "c",
+      overwrite = TRUE
+    ),
+    regex = "overwritten"
+  )
+})
+
+test_that("recode_into, don't overwrite", {
+  expect_warning(
+    recode_into(
+      x > 1 ~ "a",
+      x > 10 & x <= 15 ~ "b",
+      default = "c",
+      overwrite = FALSE
+    ),
+    regex = "altered"
+  )
+})
+
 test_that("recode_into, check mixed types", {
   x <- 1:10
   expect_error(

--- a/tests/testthat/test-recode_into.R
+++ b/tests/testthat/test-recode_into.R
@@ -9,6 +9,7 @@ test_that("recode_into", {
 })
 
 test_that("recode_into, overwrite", {
+  x <- 1:30
   expect_warning(
     recode_into(
       x > 1 ~ "a",
@@ -21,6 +22,7 @@ test_that("recode_into, overwrite", {
 })
 
 test_that("recode_into, don't overwrite", {
+  x <- 1:30
   expect_warning(
     recode_into(
       x > 1 ~ "a",


### PR DESCRIPTION
`recode_into()` by defaults overwrite former recodings when multiple recode patterns apply. This PR adds an `overwrite` argument that allows users to skip this behaviour, preserving already recoded cases and not overwrite them.

``` r
library(datawizard)
x <- 1:30

recode_into(
  x > 1 ~ "a",
  x > 10 & x <= 15 ~ "b",
  default = "c"
)
#> Warning: Several recode patterns apply to the same cases. Some of the already
#>   recoded cases will be overwritten with new values again (e.g. pattern 2
#>   overwrites the former recode of case 1).
#>   Please check if this is intentional!
#>  [1] "c" "a" "a" "a" "a" "a" "a" "a" "a" "a" "b" "b" "b" "b" "b" "a" "a" "a" "a"
#> [20] "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a"

recode_into(
  x > 1 ~ "a",
  x > 10 & x <= 15 ~ "b",
  default = "c",
  overwrite = FALSE
)
#> Warning: Several recode patterns apply to the same cases. Some of the already
#>   recoded cases will not be altered by later recode patterns. (e.g.
#>   pattern 2 also matches the former recode of case 1).
#>   Please check if this is intentional!
#>  [1] "c" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a"
#> [20] "a" "a" "a" "a" "a" "a" "a" "a" "a" "a" "a"
```
