### PR TITLE
fix wrong case number in warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.8.0.2
+Version: 0.8.0.3
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ BUG FIXES
 * Fixed issues in `data_write()` when writing labelled data into SPSS format
   and vectors were of different type as value labels.
 
+* Fixed issue in `recode_into()` with probably wrong case number printed in the
+  warning when several recode patterns match to one case.
+
 # datawizard 0.8.0
 
 BREAKING CHANGES

--- a/R/recode_into.r
+++ b/R/recode_into.r
@@ -141,25 +141,28 @@ recode_into <- function(..., data = NULL, default = NA, overwrite = TRUE, verbos
     } else {
       already_exists <- out[index] != default
     }
+    # save indices of overwritten cases
+    overwritten_cases <- which(index)[already_exists]
+    # tell user...
     if (any(already_exists) && verbose) {
       if (overwrite) {
         msg <- paste(
           "Several recode patterns apply to the same cases.",
           "Some of the already recoded cases will be overwritten with new values again",
-          sprintf("(e.g. pattern %i overwrites the former recode of case %i).", i, which(already_exists)[1])
+          sprintf("(e.g. pattern %i overwrites the former recode of case %i).", i, overwritten_cases[1])
         )
       } else {
         msg <- paste(
           "Several recode patterns apply to the same cases.",
           "Some of the already recoded cases will not be altered by later recode patterns.",
-          sprintf("(e.g. pattern %i also matches the former recode of case %i).", i, which(already_exists)[1])
+          sprintf("(e.g. pattern %i also matches the former recode of case %i).", i, overwritten_cases[1])
         )
       }
       insight::format_warning(msg, "Please check if this is intentional!")
     }
     # if user doesn't want to overwrite, remove already recoded indices
     if (!overwrite) {
-      index[which(index)[already_exists]] <- FALSE
+      index[overwritten_cases] <- FALSE
     }
     out[index] <- value
   }

--- a/tests/testthat/test-recode_into.R
+++ b/tests/testthat/test-recode_into.R
@@ -30,6 +30,14 @@ test_that("recode_into, overwrite", {
     )
   })
   expect_identical(out, c(0, 0, 1, 1, 1, 2, 2, 2, 2, 2))
+  expect_warning(
+    recode_into(
+      x >= 3 & x <= 7 ~ 1,
+      x > 5 ~ 2,
+      default = 0
+    ),
+    regex = "case 6"
+  )
 
   x <- 1:10
   expect_silent({
@@ -42,6 +50,15 @@ test_that("recode_into, overwrite", {
     )
   })
   expect_identical(out, c(0, 0, 1, 1, 1, 1, 1, 2, 2, 2))
+  expect_warning(
+    recode_into(
+      x >= 3 & x <= 7 ~ 1,
+      x > 5 ~ 2,
+      default = 0,
+      overwrite = FALSE
+    ),
+    regex = "case 6"
+  )
 })
 
 test_that("recode_into, don't overwrite", {


### PR DESCRIPTION
Was:

```r
library(datawizard)
x <- 1:10
# default behaviour: second recode pattern "x > 5" overwrites
# some of the formerly recoded cases from pattern "x >= 3 & x <= 7"
recode_into(
  x >= 3 & x <= 7 ~ 1,
  x > 5 ~ 2,
  default = 0
)
#> Warning: Several recode patterns apply to the same cases. Some of the already
#>   recoded cases will be overwritten with new values again (e.g. pattern 2
#>   overwrites the former recode of case 1).
#>   Please check if this is intentional!
#>  [1] 0 0 1 1 1 2 2 2 2 2
```

Should print "case 6" actually.