### PR TITLE
fix for functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.8.0.3
+Version: 0.8.0.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@ BUG FIXES
 * Fixed issue in `recode_into()` with probably wrong case number printed in the
   warning when several recode patterns match to one case.
 
+* Fixed issue in `data_filter()` where functions containing a `=` (e.g. when
+  naming arguments, like `grepl(pattern, x = a)`) were mistakenly seen as
+  faulty syntax. 
+
 # datawizard 0.8.0
 
 BREAKING CHANGES

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -311,29 +311,37 @@ data_filter.grouped_df <- function(x, ...) {
   tmp <- gsub(">=", "", tmp, fixed = TRUE)
   tmp <- gsub("!=", "", tmp, fixed = TRUE)
 
-  # Give more informative message to users
-  # about possible misspelled comparisons / logical conditions
-  # check if "=" instead of "==" was used?
-  if (any(grepl("=", tmp, fixed = TRUE))) {
-    insight::format_error(
-      "Filtering did not work. Please check if you need `==` (instead of `=`) for comparison."
-    )
-  }
-  # check if "&&" etc instead of "&" was used?
-  logical_operator <- NULL
-  if (any(grepl("&&", .fcondition, fixed = TRUE))) {
-    logical_operator <- "&&"
-  }
-  if (any(grepl("||", .fcondition, fixed = TRUE))) {
-    logical_operator <- "||"
-  }
-  if (!is.null(logical_operator)) {
-    insight::format_error(
-      paste0(
-        "Filtering did not work. Please check if you need `",
-        substr(logical_operator, 0, 1),
-        "` (instead of `", logical_operator, "`) as logical operator."
+  # we now want to check whether user used a "=" in the filter syntax. This
+  # typically indicates that the comparison "==" is probably wrong by using "="
+  # instead. However, if a function was provided, we indeed may have "=", e.g.
+  # if the pattern was `data_filter(out, grep("pattern", x = value))`. We thus
+  # first check if we can identify a function call, and if only continue checking
+  # when we have no function identified
+  if (!is.function(try(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), silent = TRUE))) {
+    # Give more informative message to users
+    # about possible misspelled comparisons / logical conditions
+    # check if "=" instead of "==" was used?
+    if (any(grepl("=", tmp, fixed = TRUE))) {
+      insight::format_error(
+        "Filtering did not work. Please check if you need `==` (instead of `=`) for comparison."
       )
-    )
+    }
+    # check if "&&" etc instead of "&" was used?
+    logical_operator <- NULL
+    if (any(grepl("&&", .fcondition, fixed = TRUE))) {
+      logical_operator <- "&&"
+    }
+    if (any(grepl("||", .fcondition, fixed = TRUE))) {
+      logical_operator <- "||"
+    }
+    if (!is.null(logical_operator)) {
+      insight::format_error(
+        paste0(
+          "Filtering did not work. Please check if you need `",
+          substr(logical_operator, 0, 1),
+          "` (instead of `", logical_operator, "`) as logical operator."
+        )
+      )
+    }
   }
 }

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -311,12 +311,14 @@ data_filter.grouped_df <- function(x, ...) {
   tmp <- gsub(">=", "", tmp, fixed = TRUE)
   tmp <- gsub("!=", "", tmp, fixed = TRUE)
 
-  # we now want to check whether user used a "=" in the filter syntax. This
-  # typically indicates that the comparison "==" is probably wrong by using "="
-  # instead. However, if a function was provided, we indeed may have "=", e.g.
-  # if the pattern was `data_filter(out, grep("pattern", x = value))`. We thus
-  # first check if we can identify a function call, and if only continue checking
-  # when we have no function identified
+  # We want to check whether user used a "=" in the filter syntax. This
+  # typically indicates that the comparison "==" is probably wrong by using
+  #a "=" instead of `"=="`. However, if a function was provided, we indeed
+  # may have "=", e.g. if the pattern was
+  # `data_filter(out, grep("pattern", x = value))`. We thus first check if we
+  # can identify a function call, and only continue checking for wrong syntax
+  # when we have not identified a function.
+
   if (!is.function(try(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), silent = TRUE))) {
     # Give more informative message to users
     # about possible misspelled comparisons / logical conditions

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -313,7 +313,7 @@ data_filter.grouped_df <- function(x, ...) {
 
   # We want to check whether user used a "=" in the filter syntax. This
   # typically indicates that the comparison "==" is probably wrong by using
-  #a "=" instead of `"=="`. However, if a function was provided, we indeed
+  # a "=" instead of `"=="`. However, if a function was provided, we indeed
   # may have "=", e.g. if the pattern was
   # `data_filter(out, grep("pattern", x = value))`. We thus first check if we
   # can identify a function call, and only continue checking for wrong syntax

--- a/tests/testthat/test-data_match.R
+++ b/tests/testthat/test-data_match.R
@@ -338,5 +338,5 @@ test_that("data_filter, slicing works with functions", {
   out3 <- data_filter(iris, (Sepal.Width == 3.0) & (Species == "setosa"))
   expect_identical(nrow(out3), 6L)
 
-  expect_error(data_filter(iris, (Sepal.Width = 3.0) & (Species = "setosa")))
+  expect_error(data_filter(iris, (Sepal.Width = 3.0) & (Species = "setosa"))) # nolint
 })

--- a/tests/testthat/test-data_match.R
+++ b/tests/testthat/test-data_match.R
@@ -338,5 +338,10 @@ test_that("data_filter, slicing works with functions", {
   out3 <- data_filter(iris, (Sepal.Width == 3.0) & (Species == "setosa"))
   expect_identical(nrow(out3), 6L)
 
-  expect_error(data_filter(iris, (Sepal.Width = 3.0) & (Species = "setosa"))) # nolint
+  # styler: off
+  expect_error(
+    data_filter(iris, (Sepal.Width = 3.0) & (Species = "setosa")), # nolint
+    regex = "Filtering did not work"
+  )
+  # styler: on
 })

--- a/tests/testthat/test-data_match.R
+++ b/tests/testthat/test-data_match.R
@@ -320,3 +320,23 @@ test_that("data_filter with groups, different ways of dots", {
   expect_identical(out1, out2)
   expect_identical(out1, out3)
 })
+
+
+test_that("data_filter, slicing works with functions", {
+  d <- data.frame(
+    a = c("aa", "a1", "bb", "b1", "cc", "c1"),
+    b = 1:6,
+    stringsAsFactors = FALSE
+  )
+
+  rows <- grep("^[A-Za-z][0-9]$", x = d$a)
+  out1 <- data_filter(d, rows)
+  out2 <- data_filter(d, grep("^[A-Za-z][0-9]$", x = d$a))
+
+  expect_identical(out1, out2)
+
+  out3 <- data_filter(iris, (Sepal.Width == 3.0) & (Species == "setosa"))
+  expect_identical(nrow(out3), 6L)
+
+  expect_error(data_filter(iris, (Sepal.Width = 3.0) & (Species = "setosa")))
+})


### PR DESCRIPTION
was:

``` r
library(datawizard)

d <- data.frame(
  a = c("aa", "a1", "bb", "b1", "cc", "c1"),
  b = 1:6,
  stringsAsFactors = FALSE
)

data_filter(d, grep("^[A-Za-z][0-9]$", x = d$a))
#> Error: Filtering did not work. Please check if you need `==` (instead of `=`)
#>   for comparison.
```

now is:

``` r
data_filter(d, grep("^[A-Za-z][0-9]$", x = d$a))
#>    a b
#> 2 a1 2
#> 4 b1 4
#> 6 c1 6
```

<sup>Created on 2023-06-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
