### PR TITLE
data_modify() gains .it and .at

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.9.1
+Version: 0.9.1.1
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),
@@ -72,7 +72,7 @@ VignetteBuilder:
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/Needs/website:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# datawizard 0.9.2
+
+CHANGES
+
+* `data_modify()` gets three new arguments, `.at`, `.if` and `.modify`, to modify
+  variables at specific positions or based on logical conditions.
+
 # datawizard 0.9.1
 
 CHANGES

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -28,11 +28,12 @@
 #'
 #' @param .at A character vector of variable names that should be modified. This
 #' argument is used in combination with the `.modify` argument. Note that only one
-#' of `.at` or `.if` can be provided, but not both at the same time.
+#' of `.at` or `.if` can be provided, but not both at the same time. Newly created
+#' variables in `...` are not affected by `.at`.
 #' @param .if A function that returns `TRUE` for columns in the data frame where
 #' `.if` applies. This argument is used in combination with the `.modify` argument.
 #' Note that only one of `.at` or `.if` can be provided, but not both at the same
-#' time.
+#' time. Newly created variables in `...` are not affected by `.if`.
 #' @param .modify A function that modifies the variables defined in `.at` or `.if`.
 #' This argument is used in combination with either the `.at` or the `.if` argument.
 #' Note that the modified variable (i.e. the result from `.modify`) must be either
@@ -112,6 +113,16 @@
 #' # can be combined with dots
 #' data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
 #'
+#' # note that new variables cannot be used in `.at` or `.if` arguments
+#' # this example would throw an error
+#' \dontrun{
+#' data_modify(
+#'   d,
+#'   new_length = Petal.Length * 2,
+#'   .at = c("Species", "new_length"),
+#'   .modify = as.numeric
+#' )}
+#' 
 #' # combine "data_find()" and ".at" argument
 #' out <- data_modify(
 #'   d,

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -233,6 +233,7 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
   # we need to evaluate dots here, and pass them with "do.call" to
   # the data.frame method later...
   dots <- match.call(expand.dots = FALSE)[["..."]]
+  column_names <- colnames(data)
 
   # works only for dplyr >= 0.8.0
   grps <- attr(data, "groups", exact = TRUE)

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -341,11 +341,7 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
     found <- .at[.at %in% column_names]
     if (length(found)) {
       for (i in found) {
-        result <- tryCatch(
-          .modify(data[[i]]),
-          warning = function(e) e,
-          error = function(e) e
-        )
+        result <- tryCatch(.modify(data[[i]]), warning = function(e) e, error = function(e) e)
         if (inherits(result, "error")) {
           insight::format_error(
             paste0("Error in modifying variable \"", i, "\": ", result$message),

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -341,7 +341,25 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
     found <- .at[.at %in% column_names]
     if (length(found)) {
       for (i in found) {
-        data[[i]] <- .modify(data[[i]])
+        result <- tryCatch(
+          .modify(data[[i]]),
+          warning = function(e) e,
+          error = function(e) e
+        )
+        if (inherits(result, "error")) {
+          insight::format_error(
+            paste0("Error in modifying variable \"", i, "\": ", result$message),
+            "Please check if you correctly specified the `.modify` function."
+          )
+        } else if (inherits(result, "warning")) {
+          insight::format_warning(
+            paste0("Warning when modifying variable \"", i, "\": ", result$message),
+            "Results may be incorrect or unexpected."
+          )
+          data[[i]] <- result
+        } else {
+          data[[i]] <- result
+        }
       }
     } else {
       insight::format_alert("No variables found in the dataset that match the `.if` or `.at` argument.")

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -329,7 +329,7 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
   if (!is.null(.at) && !is.null(.if)) {
     insight::format_error("You cannot use both `.at` and `.if` at the same time.")
   }
-  # make sure either .at or .if is defined, not both
+  # make sure at least one of .at or .if is defined
   if (is.null(.at) && is.null(.if)) {
     insight::format_error("You need to specify either `.at` or `.if`.")
   }

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -26,6 +26,14 @@
 #' Note that newly created variables can be used in subsequent expressions.
 #' See also 'Examples'.
 #'
+#' @param .at A character vector of variable names that should be modified. This
+#' argument is used in combination with the `.modify` argument.
+#' @param .if A function that returns `TRUE` for columns in the data frame where
+#' `.if` applies. This argument is used in combination with the `.modify` argument.
+#' @param .modify A function that modifies the variables defined in `.at` or `.if`.
+#' This argument is used in combination with either the `.at` or the `.if`argument.
+#' If `.modify` is not provided, `.at` and `.if` are ignored.
+#'
 #' @note `data_modify()` can also be used inside functions. However, it is
 #' recommended to pass the recode-expression as character vector or list of
 #' characters.
@@ -91,6 +99,15 @@
 #'
 #' new_exp <- c("SW_double = 2 * Sepal.Width", "SW_fraction = SW_double / 10")
 #' foo(iris, new_exp)
+#'
+#' # modify at specific positions or if condition is met
+#' d <- iris[1:5, ]
+#' data_modify(d, .at = "Species", .modify = as.numeric)
+#' data_modify(d, .if = is.factor, .modify = as.numeric)
+#'
+#' # can be combined with dots
+#' data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
+#'
 #' @export
 data_modify <- function(data, ...) {
   UseMethod("data_modify")
@@ -102,113 +119,120 @@ data_modify.default <- function(data, ...) {
 }
 
 #' @export
-data_modify.data.frame <- function(data, ...) {
+data_modify.data.frame <- function(data, ..., .if = NULL, .at = NULL, .modify = NULL) {
   dots <- eval(substitute(alist(...)))
   column_names <- colnames(data)
 
-  # we check for character vector of expressions, in which case
-  # "dots" should be unnamed
-  if (is.null(names(dots))) {
-    # if we have multiple strings, concatenate them to a character vector
-    # and put it into a list...
-    if (length(dots) > 1) {
-      if (all(vapply(dots, is.character, logical(1)))) {
-        dots <- list(unlist(dots))
-      } else {
-        insight::format_error("You cannot mix string and literal representation of expressions.")
+  # check if we have dots, or only at/modify ----
+
+  if (length(dots)) {
+    # we check for character vector of expressions, in which case
+    # "dots" should be unnamed
+    if (is.null(names(dots))) {
+      # if we have multiple strings, concatenate them to a character vector
+      # and put it into a list...
+      if (length(dots) > 1) {
+        if (all(vapply(dots, is.character, logical(1)))) {
+          dots <- list(unlist(dots))
+        } else {
+          insight::format_error("You cannot mix string and literal representation of expressions.")
+        }
+      }
+      # expression is given as character string, e.g.
+      # a <- "double_SepWidth = 2 * Sepal.Width"
+      # data_modify(iris, a)
+      # or as character vector, e.g.
+      # data_modify(iris, c("var_a = Sepal.Width / 10", "var_b = Sepal.Width * 10"))
+      character_symbol <- tryCatch(.dynEval(dots[[1]]), error = function(e) NULL)
+      # do we have a character vector? Then we can proceed
+      if (is.character(character_symbol)) {
+        dots <- lapply(character_symbol, function(s) {
+          # turn value from character vector into expression
+          str2lang(.dynEval(s))
+        })
+        names(dots) <- vapply(dots, function(n) insight::safe_deparse(n[[2]]), character(1))
       }
     }
-    # expression is given as character string, e.g.
-    # a <- "double_SepWidth = 2 * Sepal.Width"
-    # data_modify(iris, a)
-    # or as character vector, e.g.
-    # data_modify(iris, c("var_a = Sepal.Width / 10", "var_b = Sepal.Width * 10"))
-    character_symbol <- tryCatch(.dynEval(dots[[1]]), error = function(e) NULL)
-    # do we have a character vector? Then we can proceed
-    if (is.character(character_symbol)) {
-      dots <- lapply(character_symbol, function(s) {
-        # turn value from character vector into expression
-        str2lang(.dynEval(s))
-      })
-      names(dots) <- vapply(dots, function(n) insight::safe_deparse(n[[2]]), character(1))
-    }
-  }
 
-  for (i in seq_along(dots)) {
-    # iterate expressions for new variables
-    symbol <- dots[[i]]
+    for (i in seq_along(dots)) {
+      # iterate expressions for new variables
+      symbol <- dots[[i]]
 
-    # expression is given as character string in a variable, but named, e.g.
-    # a <- "2 * Sepal.Width"
-    # data_modify(iris, double_SepWidth = a)
-    # we reconstruct the symbol as if it were provided as literal expression.
-    # However, we need to check that we don't have a character vector,
-    # like: data_modify(iris, new_var = "a")
-    # this one should be recycled instead.
-    if (!is.character(symbol)) {
-      eval_symbol <- .dynEval(symbol, ifnotfound = NULL)
-      if (is.character(eval_symbol)) {
-        symbol <- try(str2lang(paste0(names(dots)[i], " = ", eval_symbol)), silent = TRUE)
-        # we may have the edge-case of having a function that returns a character
-        # vector, like "new_var = sample(letters[1:3])". In this case, "eval_symbol"
-        # is of type character, but no symbol, thus str2lang() above creates a
-        # wrong pattern. We then take "eval_symbol" as character input.
-        if (inherits(symbol, "try-error")) {
-          symbol <- str2lang(paste0(
-            names(dots)[i],
-            " = c(", paste0("\"", eval_symbol, "\"", collapse = ","), ")"
+      # expression is given as character string in a variable, but named, e.g.
+      # a <- "2 * Sepal.Width"
+      # data_modify(iris, double_SepWidth = a)
+      # we reconstruct the symbol as if it were provided as literal expression.
+      # However, we need to check that we don't have a character vector,
+      # like: data_modify(iris, new_var = "a")
+      # this one should be recycled instead.
+      if (!is.character(symbol)) {
+        eval_symbol <- .dynEval(symbol, ifnotfound = NULL)
+        if (is.character(eval_symbol)) {
+          symbol <- try(str2lang(paste0(names(dots)[i], " = ", eval_symbol)), silent = TRUE)
+          # we may have the edge-case of having a function that returns a character
+          # vector, like "new_var = sample(letters[1:3])". In this case, "eval_symbol"
+          # is of type character, but no symbol, thus str2lang() above creates a
+          # wrong pattern. We then take "eval_symbol" as character input.
+          if (inherits(symbol, "try-error")) {
+            symbol <- str2lang(paste0(
+              names(dots)[i],
+              " = c(", paste0("\"", eval_symbol, "\"", collapse = ","), ")"
+            ))
+          }
+        }
+      }
+
+      # finally, we can evaluate expression and get values for new variables
+      new_variable <- try(with(data, eval(symbol)), silent = TRUE)
+
+      # successful, or any errors, like misspelled variable name?
+      if (inherits(new_variable, "try-error")) {
+        # in which step did error happen?
+        step_number <- switch(as.character(i),
+          "1" = "the first expression",
+          "2" = "the second expression",
+          "3" = "the third expression",
+          paste("expression", i)
+        )
+        step_msg <- paste0("There was an error in ", step_number, ".")
+        # try to find out which variable was the cause for the error
+        error_msg <- attributes(new_variable)$condition$message
+        if (grepl("object '(.*)' not found", error_msg)) {
+          error_var <- gsub("object '(.*)' not found", "\\1", error_msg)
+          insight::format_error(
+            paste0(step_msg, " Variable \"", error_var, "\" was not found in the dataset or in the environment."),
+            .misspelled_string(colnames(data), error_var, "Possibly misspelled or not yet defined?")
+          )
+        } else {
+          insight::format_error(paste0(
+            step_msg, " ", insight::format_capitalize(error_msg),
+            ". Possibly misspelled or not yet defined?"
           ))
         }
       }
-    }
 
-    # finally, we can evaluate expression and get values for new variables
-    new_variable <- try(with(data, eval(symbol)), silent = TRUE)
-
-    # successful, or any errors, like misspelled variable name?
-    if (inherits(new_variable, "try-error")) {
-      # in which step did error happen?
-      step_number <- switch(as.character(i),
-        "1" = "the first expression",
-        "2" = "the second expression",
-        "3" = "the third expression",
-        paste("expression", i)
-      )
-      step_msg <- paste0("There was an error in ", step_number, ".")
-      # try to find out which variable was the cause for the error
-      error_msg <- attributes(new_variable)$condition$message
-      if (grepl("object '(.*)' not found", error_msg)) {
-        error_var <- gsub("object '(.*)' not found", "\\1", error_msg)
+      # give informative error when new variable doesn't match number of rows
+      if (!is.null(new_variable) && length(new_variable) != nrow(data) && (nrow(data) %% length(new_variable)) != 0) {
         insight::format_error(
-          paste0(step_msg, " Variable \"", error_var, "\" was not found in the dataset or in the environment."),
-          .misspelled_string(colnames(data), error_var, "Possibly misspelled or not yet defined?")
+          "New variable has not the same length as the other variables in the data frame and cannot be recycled."
         )
-      } else {
-        insight::format_error(paste0(
-          step_msg, " ", insight::format_capitalize(error_msg),
-          ". Possibly misspelled or not yet defined?"
-        ))
       }
-    }
 
-    # give informative error when new variable doesn't match number of rows
-    if (!is.null(new_variable) && length(new_variable) != nrow(data) && (nrow(data) %% length(new_variable)) != 0) {
-      insight::format_error(
-        "New variable has not the same length as the other variables in the data frame and cannot be recycled."
-      )
+      data[[names(dots)[i]]] <- new_variable
     }
-
-    data[[names(dots)[i]]] <- new_variable
   }
+
+  # check if we have at/modify ----
+  data <- .modify_at(data, .at, .if, .modify, column_names)
 
   data
 }
 
 #' @export
-data_modify.grouped_df <- function(data, ...) {
+data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = NULL) {
   # we need to evaluate dots here, and pass them with "do.call" to
   # the data.frame method later...
-  dots <- match.call(expand.dots = FALSE)$`...`
+  dots <- match.call(expand.dots = FALSE)[["..."]]
 
   # works only for dplyr >= 0.8.0
   grps <- attr(data, "groups", exact = TRUE)
@@ -262,8 +286,55 @@ data_modify.grouped_df <- function(data, ...) {
     data[rows, ] <- data_modify.data.frame(data[rows, ], ...)
   }
 
+  # check if we have at/modify ----
+  data <- .modify_at(data, .at, .if, .modify, column_names)
+
   # set back attributes and class
   data <- .replace_attrs(data, attr_data)
   class(data) <- class_attr
+  data
+}
+
+
+# helper -------------
+
+.modify_at <- function(data, .at, .if, .modify, column_names) {
+  # make sure either .at or .if is defined, not both
+  if (!is.null(.at) && !is.null(.if)) {
+    insight::format_error("You cannot use both `.at` and `.if` at the same time.")
+  }
+  if ((!is.null(.at) || !is.null(.if)) && !is.null(.modify)) {
+    # if we have ".if" defined, specify ".at"
+    if (!is.null(.if)) {
+      .at <- column_names[vapply(data[column_names], .if, logical(1))]
+    }
+    # make sure "modify" is a function
+    if (!is.function(.modify)) {
+      insight::format_error("`.modify` must be a function.")
+    }
+    # check for valid defined column names
+    if (!all(.at %in% column_names)) {
+      not_found <- .at[!.at %in% column_names]
+      insight::format_alert(
+        paste0(
+          "Variable",
+          ifelse(length(not_found) > 1, "s ", " "),
+          text_concatenate(not_found, enclose = "\""),
+          ifelse(length(not_found) > 1, "were", "was"),
+          " not found in the dataset."
+        ),
+        .misspelled_string(column_names, not_found, "Possibly misspelled or not yet defined?")
+      )
+    }
+    # modify variables
+    found <- .at[.at %in% column_names]
+    if (length(found)) {
+      for (i in found) {
+        data[[i]] <- .modify(data[[i]])
+      }
+    } else {
+      insight::format_alert("No variables found in the dataset that match the `.if` or `.at` argument.")
+    }
+  }
   data
 }

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -322,7 +322,7 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
           "Variable",
           ifelse(length(not_found) > 1, "s ", " "),
           text_concatenate(not_found, enclose = "\""),
-          ifelse(length(not_found) > 1, "were", "was"),
+          ifelse(length(not_found) > 1, " were", " was"),
           " not found in the dataset."
         ),
         .misspelled_string(column_names, not_found, "Possibly misspelled or not yet defined?")

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -108,6 +108,15 @@
 #' # can be combined with dots
 #' data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
 #'
+#' # combine "data_find()" and ".at" argument
+#' out <- data_modify(
+#'   d,
+#'   .at = data_find(d, select = starts_with("Sepal")),
+#'   .modify = as.factor
+#' )
+#' # "Sepal.Length" and "Sepal.Width" are now factors
+#' str(out)
+#'
 #' @export
 data_modify <- function(data, ...) {
   UseMethod("data_modify")

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -352,22 +352,16 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
       .misspelled_string(column_names, not_found, "Possibly misspelled or not yet defined?")
     )
   }
-  # modify variables
-  found <- .at[.at %in% column_names]
-  if (length(found)) {
-    for (i in found) {
-      result <- tryCatch(.modify(data[[i]]), warning = function(e) e, error = function(e) e)
-      if (inherits(result, c("error", "warning"))) {
-        insight::format_error(
-          paste0("Error in modifying variable \"", i, "\": ", result$message),
-          "Please check if you correctly specified the `.modify` function."
-        )
-      } else {
-        data[[i]] <- result
-      }
+  for (i in .at) {
+    result <- tryCatch(.modify(data[[i]]), warning = function(e) e, error = function(e) e)
+    if (inherits(result, c("error", "warning"))) {
+      insight::format_error(
+        paste0("Error in modifying variable \"", i, "\": ", result$message),
+        "Please check if you correctly specified the `.modify` function."
+      )
+    } else {
+      data[[i]] <- result
     }
-  } else {
-    insight::format_error("No variables found in the dataset that match the `.if` or `.at` argument.")
   }
 
   data

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -118,6 +118,7 @@ data_modify.default <- function(data, ...) {
   insight::format_error("`data` must be a data frame.")
 }
 
+#' @rdname data_modify
 #' @export
 data_modify.data.frame <- function(data, ..., .if = NULL, .at = NULL, .modify = NULL) {
   dots <- eval(substitute(alist(...)))

--- a/R/normalize.R
+++ b/R/normalize.R
@@ -202,15 +202,15 @@ normalize.grouped_df <- function(x,
   # create the new variables and updates "select", so new variables are processed
   if (!isFALSE(append)) {
     # process arguments
-    args <- .process_append(
+    my_args <- .process_append(
       x,
       select,
       append,
       append_suffix = "_n"
     )
     # update processed arguments
-    x <- args$x
-    select <- args$select
+    x <- my_args$x
+    select <- my_args$select
   }
 
   x <- as.data.frame(x)
@@ -274,15 +274,15 @@ normalize.data.frame <- function(x,
   # create the new variables and updates "select", so new variables are processed
   if (!isFALSE(append)) {
     # process arguments
-    args <- .process_append(
+    my_args <- .process_append(
       x,
       select,
       append,
       append_suffix = "_n"
     )
     # update processed arguments
-    x <- args$x
-    select <- args$select
+    x <- my_args$x
+    select <- my_args$select
   }
 
   x[select] <- lapply(

--- a/man/data_modify.Rd
+++ b/man/data_modify.Rd
@@ -2,9 +2,12 @@
 % Please edit documentation in R/data_modify.R
 \name{data_modify}
 \alias{data_modify}
+\alias{data_modify.data.frame}
 \title{Create new variables in a data frame}
 \usage{
 data_modify(data, ...)
+
+\method{data_modify}{data.frame}(data, ..., .if = NULL, .at = NULL, .modify = NULL)
 }
 \arguments{
 \item{data}{A data frame}
@@ -32,11 +35,11 @@ Example: \code{Petal.Width = NULL}.
 Note that newly created variables can be used in subsequent expressions.
 See also 'Examples'.}
 
-\item{.at}{A character vector of variable names that should be modified. This
-argument is used in combination with the \code{.modify} argument.}
-
 \item{.if}{A function that returns \code{TRUE} for columns in the data frame where
 \code{.if} applies. This argument is used in combination with the \code{.modify} argument.}
+
+\item{.at}{A character vector of variable names that should be modified. This
+argument is used in combination with the \code{.modify} argument.}
 
 \item{.modify}{A function that modifies the variables defined in \code{.at} or \code{.if}.
 This argument is used in combination with either the \code{.at} or the \code{.if}argument.

--- a/man/data_modify.Rd
+++ b/man/data_modify.Rd
@@ -31,6 +31,16 @@ Example: \code{Petal.Width = NULL}.
 
 Note that newly created variables can be used in subsequent expressions.
 See also 'Examples'.}
+
+\item{.at}{A character vector of variable names that should be modified. This
+argument is used in combination with the \code{.modify} argument.}
+
+\item{.if}{A function that returns \code{TRUE} for columns in the data frame where
+\code{.if} applies. This argument is used in combination with the \code{.modify} argument.}
+
+\item{.modify}{A function that modifies the variables defined in \code{.at} or \code{.if}.
+This argument is used in combination with either the \code{.at} or the \code{.if}argument.
+If \code{.modify} is not provided, \code{.at} and \code{.if} are ignored.}
 }
 \description{
 Create new variables or modify existing variables in a data frame. Unlike \code{base::transform()}, \code{data_modify()}
@@ -103,4 +113,13 @@ foo(iris, "var_a = Sepal.Width / 10")
 
 new_exp <- c("SW_double = 2 * Sepal.Width", "SW_fraction = SW_double / 10")
 foo(iris, new_exp)
+
+# modify at specific positions or if condition is met
+d <- iris[1:5, ]
+data_modify(d, .at = "Species", .modify = as.numeric)
+data_modify(d, .if = is.factor, .modify = as.numeric)
+
+# can be combined with dots
+data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
+
 }

--- a/man/data_modify.Rd
+++ b/man/data_modify.Rd
@@ -38,11 +38,12 @@ See also 'Examples'.}
 \item{.if}{A function that returns \code{TRUE} for columns in the data frame where
 \code{.if} applies. This argument is used in combination with the \code{.modify} argument.
 Note that only one of \code{.at} or \code{.if} can be provided, but not both at the same
-time.}
+time. Newly created variables in \code{...} are not affected by \code{.if}.}
 
 \item{.at}{A character vector of variable names that should be modified. This
 argument is used in combination with the \code{.modify} argument. Note that only one
-of \code{.at} or \code{.if} can be provided, but not both at the same time.}
+of \code{.at} or \code{.if} can be provided, but not both at the same time. Newly created
+variables in \code{...} are not affected by \code{.at}.}
 
 \item{.modify}{A function that modifies the variables defined in \code{.at} or \code{.if}.
 This argument is used in combination with either the \code{.at} or the \code{.if} argument.
@@ -128,6 +129,16 @@ data_modify(d, .if = is.factor, .modify = as.numeric)
 
 # can be combined with dots
 data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
+
+# note that new variables cannot be used in `.at` or `.if` arguments
+# this example would throw an error
+\dontrun{
+data_modify(
+  d,
+  new_length = Petal.Length * 2,
+  .at = c("Species", "new_length"),
+  .modify = as.numeric
+)}
 
 # combine "data_find()" and ".at" argument
 out <- data_modify(

--- a/man/data_modify.Rd
+++ b/man/data_modify.Rd
@@ -125,4 +125,13 @@ data_modify(d, .if = is.factor, .modify = as.numeric)
 # can be combined with dots
 data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
 
+# combine "data_find()" and ".at" argument
+out <- data_modify(
+  d,
+  .at = data_find(d, select = starts_with("Sepal")),
+  .modify = as.factor
+)
+# "Sepal.Length" and "Sepal.Width" are now factors
+str(out)
+
 }

--- a/man/data_modify.Rd
+++ b/man/data_modify.Rd
@@ -36,14 +36,18 @@ Note that newly created variables can be used in subsequent expressions.
 See also 'Examples'.}
 
 \item{.if}{A function that returns \code{TRUE} for columns in the data frame where
-\code{.if} applies. This argument is used in combination with the \code{.modify} argument.}
+\code{.if} applies. This argument is used in combination with the \code{.modify} argument.
+Note that only one of \code{.at} or \code{.if} can be provided, but not both at the same
+time.}
 
 \item{.at}{A character vector of variable names that should be modified. This
-argument is used in combination with the \code{.modify} argument.}
+argument is used in combination with the \code{.modify} argument. Note that only one
+of \code{.at} or \code{.if} can be provided, but not both at the same time.}
 
 \item{.modify}{A function that modifies the variables defined in \code{.at} or \code{.if}.
-This argument is used in combination with either the \code{.at} or the \code{.if}argument.
-If \code{.modify} is not provided, \code{.at} and \code{.if} are ignored.}
+This argument is used in combination with either the \code{.at} or the \code{.if} argument.
+Note that the modified variable (i.e. the result from \code{.modify}) must be either
+of length 1 or of same length as the input variable.}
 }
 \description{
 Create new variables or modify existing variables in a data frame. Unlike \code{base::transform()}, \code{data_modify()}

--- a/man/datawizard-package.Rd
+++ b/man/datawizard-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{datawizard-package}
 \alias{datawizard-package}
-\alias{_PACKAGE}
 \alias{datawizard}
 \title{datawizard: Easy Data Wrangling and Statistical Transformations}
 \description{

--- a/tests/testthat/test-data_modify.R
+++ b/tests/testthat/test-data_modify.R
@@ -522,12 +522,20 @@ test_that("data_modify .if/.at arguments", {
     regex = "Variables \"Hi\" and \"Test\""
   )
   expect_error(
+    data_modify(d, .modify = as.numeric),
+    regex = "You need to specify"
+  )
+  expect_error(
     data_modify(d, .at = "Species", .modify = function(x) 2 / y + x),
     regex = "Error in modifying variable"
   )
   expect_error(
     data_modify(d, .at = "Species", .modify = function(x) 2 * x),
     regex = "Error in modifying variable"
+  )
+  expect_error(
+    data_modify(d, .at = "Species", .if = is.factor),
+    regex = "You need to specify"
   )
   # newly created variables are not modified by if/at
   out <- data_modify(d, new_length = Petal.Length * 2, .if = is.numeric, .modify = as.factor)

--- a/tests/testthat/test-data_modify.R
+++ b/tests/testthat/test-data_modify.R
@@ -513,24 +513,23 @@ test_that("data_modify .if/.at arguments", {
     data_modify(d, .at = "Species", .modify = "a"),
     regex = "`.modify` must"
   )
-  expect_message(
+  expect_error(
     data_modify(d, .at = c("Species", "Test"), .modify = as.numeric),
     regex = "Variable \"Test\""
   )
-  expect_message(
+  expect_error(
     data_modify(d, .at = c("Species", "Hi", "Test"), .modify = as.numeric),
     regex = "Variables \"Hi\" and \"Test\""
-  )
-  expect_message(
-    data_modify(d, .at = c("Hi", "Test"), .modify = as.numeric),
-    regex = "No variables found in the dataset"
   )
   expect_error(
     data_modify(d, .at = "Species", .modify = function(x) 2 / y + x),
     regex = "Error in modifying variable"
   )
-  expect_warning(
+  expect_error(
     data_modify(d, .at = "Species", .modify = function(x) 2 * x),
-    regex = "Warning when modifying variable"
+    regex = "Error in modifying variable"
   )
+  # newly created variables are not modified by if/at
+  out <- data_modify(d, new_length = Petal.Length * 2, .if = is.numeric, .modify = as.factor)
+  expect_identical(out$new_length, c(2.8, 2.8, 2.6, 3, 2.8))
 })

--- a/tests/testthat/test-data_modify.R
+++ b/tests/testthat/test-data_modify.R
@@ -490,3 +490,39 @@ test_that("data_modify works with functions that return character vectors", {
   out <- data_modify(iris, grp = sample(letters[1:3], nrow(iris), TRUE))
   expect_identical(head(out$grp), c("c", "c", "c", "b", "c", "b"))
 })
+
+
+test_that("data_modify .if/.at arguments", {
+  data(iris)
+  d <- iris[1:5, ]
+  out <- data_modify(d, .at = "Species", .modify = as.numeric)
+  expect_identical(out$Species, c(1, 1, 1, 1, 1))
+  out <- data_modify(d, .if = is.factor, .modify = as.numeric)
+  expect_identical(out$Species, c(1, 1, 1, 1, 1))
+  out <- data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
+  expect_identical(out$Species, c(1, 1, 1, 1, 1))
+  expect_named(out, c(
+    "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width",
+    "Species", "new_length"
+  ))
+  expect_error(
+    data_modify(d, .at = "Species", .if = is.factor, .modify = as.numeric),
+    regex = "You cannot use both"
+  )
+  expect_error(
+    data_modify(d, .at = "Species", .modify = "a"),
+    regex = "`.modify` must"
+  )
+  expect_message(
+    data_modify(d, .at = c("Species", "Test"), .modify = as.numeric),
+    regex = "Variable \"Test\""
+  )
+  expect_message(
+    data_modify(d, .at = c("Species", "Hi", "Test"), .modify = as.numeric),
+    regex = "Variables \"Hi\" and \"Test\""
+  )
+  expect_message(
+    data_modify(d, .at = c("Hi", "Test"), .modify = as.numeric),
+    regex = "No variables found in the dataset"
+  )
+})

--- a/tests/testthat/test-data_modify.R
+++ b/tests/testthat/test-data_modify.R
@@ -525,4 +525,12 @@ test_that("data_modify .if/.at arguments", {
     data_modify(d, .at = c("Hi", "Test"), .modify = as.numeric),
     regex = "No variables found in the dataset"
   )
+  expect_error(
+    data_modify(d, .at = "Species", .modify = function(x) 2 / y + x),
+    regex = "Error in modifying variable"
+  )
+  expect_warning(
+    data_modify(d, .at = "Species", .modify = function(x) 2 * x),
+    regex = "Warning when modifying variable"
+  )
 })


### PR DESCRIPTION
``` r
library(datawizard)
data(iris)
# modify at specific positions or if condition is met
d <- iris[1:5, ]
data_modify(d, .at = "Species", .modify = as.numeric)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1          5.1         3.5          1.4         0.2       1
#> 2          4.9         3.0          1.4         0.2       1
#> 3          4.7         3.2          1.3         0.2       1
#> 4          4.6         3.1          1.5         0.2       1
#> 5          5.0         3.6          1.4         0.2       1
data_modify(d, .if = is.factor, .modify = as.numeric)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1          5.1         3.5          1.4         0.2       1
#> 2          4.9         3.0          1.4         0.2       1
#> 3          4.7         3.2          1.3         0.2       1
#> 4          4.6         3.1          1.5         0.2       1
#> 5          5.0         3.6          1.4         0.2       1

# can be combined with dots
data_modify(d, new_length = Petal.Length * 2, .at = "Species", .modify = as.numeric)
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species new_length
#> 1          5.1         3.5          1.4         0.2       1        2.8
#> 2          4.9         3.0          1.4         0.2       1        2.8
#> 3          4.7         3.2          1.3         0.2       1        2.6
#> 4          4.6         3.1          1.5         0.2       1        3.0
#> 5          5.0         3.6          1.4         0.2       1        2.8
```

<sup>Created on 2024-02-06 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
