### PR TITLE
`data_tabulate()` gains a `weights` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.9.1
+Version: 0.9.1.2
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),
@@ -72,7 +72,7 @@ VignetteBuilder:
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/Needs/website:

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ CHANGES
 * `data_modify()` gets three new arguments, `.at`, `.if` and `.modify`, to modify
   variables at specific positions or based on logical conditions.
 
-* `data_tabulate()` gets `weights` argument, to compute weighted frequency tables.
+* `data_tabulate()` gets a `weights` argument, to compute weighted frequency tables.
 
 # datawizard 0.9.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ CHANGES
 * `data_modify()` gets three new arguments, `.at`, `.if` and `.modify`, to modify
   variables at specific positions or based on logical conditions.
 
+* `data_tabulate()` gets `weights` argument, to compute weighted frequency tables.
+
 # datawizard 0.9.1
 
 CHANGES

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -122,7 +122,7 @@
 #'   .at = c("Species", "new_length"),
 #'   .modify = as.numeric
 #' )}
-#' 
+#'
 #' # combine "data_find()" and ".at" argument
 #' out <- data_modify(
 #'   d,

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -80,7 +80,7 @@ data_tabulate.default <- function(x, drop_levels = FALSE, weights = NULL, name =
 
   # check for correct length of weights - must be equal to "x"
   if (!is.null(weights) && length(weights) != length(x)) {
-    insight::format_error("Length of weights must be equal to length of `x`.")
+    insight::format_error("Length of `weights` must be equal to length of `x`.")
   }
 
   # frequency table

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -307,7 +307,12 @@ print.dw_data_tabulate <- function(x, big_mark = NULL, ...) {
   a$valid_n <- .add_commas_in_numbers(a$valid_n, big_mark)
 
   # summary of total and valid N (we may add mean/sd as well?)
-  summary_line <- sprintf("# total N=%s valid N=%s\n\n", a$total_n, a$valid_n)
+  summary_line <- sprintf(
+    "# total N=%s valid N=%s%s\n\n",
+    a$total_n,
+    a$valid_n,
+    ifelse(is.null(a$weights), "", " (weighted)")
+  )
   cat(insight::print_color(summary_line, "blue"))
 
   # remove information that goes into the header/footer
@@ -332,7 +337,12 @@ print_html.dw_data_tabulate <- function(x, big_mark = NULL, ...) {
   caption <- .table_header(x, "html")
 
   # summary of total and valid N (we may add mean/sd as well?)
-  footer <- sprintf("total N=%i valid N=%i\n\n", a$total_n, a$valid_n)
+  footer <- sprintf(
+    "total N=%i valid N=%i%s",
+    a$total_n,
+    a$valid_n,
+    ifelse(is.null(a$weights), "", " (weighted)")
+  )
 
   # remove information that goes into the header/footer
   x$Variable <- NULL
@@ -357,7 +367,12 @@ print_md.dw_data_tabulate <- function(x, big_mark = NULL, ...) {
   caption <- .table_header(x, "markdown")
 
   # summary of total and valid N (we may add mean/sd as well?)
-  footer <- sprintf("total N=%i valid N=%i\n\n", a$total_n, a$valid_n)
+  footer <- sprintf(
+    "total N=%i valid N=%i%s\n\n",
+    a$total_n,
+    a$valid_n,
+    ifelse(is.null(a$weights), "", " (weighted)")
+  )
 
   # remove information that goes into the header/footer
   x$Variable <- NULL

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -141,6 +141,7 @@ data_tabulate.default <- function(x, drop_levels = FALSE, weights = NULL, name =
   attr(out, "object") <- obj_name
   attr(out, "group_variable") <- group_variable
   attr(out, "duplicate_varnames") <- duplicated(out$Variable)
+  attr(out, "weights") <- weights
 
   attr(out, "total_n") <- sum(out$N, na.rm = TRUE)
   attr(out, "valid_n") <- sum(out$N[-length(out$N)], na.rm = TRUE)
@@ -177,6 +178,7 @@ data_tabulate.data.frame <- function(x,
 
   class(out) <- c("dw_data_tabulates", "list")
   attr(out, "collapse") <- isTRUE(collapse)
+  attr(out, "is_weighted") <- !is.null(weights)
 
   out
 }
@@ -231,6 +233,7 @@ data_tabulate.grouped_df <- function(x,
   }
   class(out) <- c("dw_data_tabulates", "list")
   attr(out, "collapse") <- isTRUE(collapse)
+  attr(out, "is_weighted") <- !is.null(weights)
 
   out
 }
@@ -373,6 +376,9 @@ print_md.dw_data_tabulate <- function(x, big_mark = NULL, ...) {
 
 #' @export
 print.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
+  # check if we have weights
+  is_weighted <- isTRUE(attributes(x)$is_weighted)
+
   a <- attributes(x)
   if (!isTRUE(a$collapse) || length(x) == 1) {
     for (i in seq_along(x)) {
@@ -390,7 +396,11 @@ print.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
     })
 
     out <- do.call(rbind, x)
-    cat(insight::print_color("# Frequency Table\n\n", "blue"))
+    if (is_weighted) {
+      cat(insight::print_color("# Frequency Table (weighted)\n\n", "blue"))
+    } else {
+      cat(insight::print_color("# Frequency Table\n\n", "blue"))
+    }
 
     # print table
     cat(insight::export_table(
@@ -405,6 +415,9 @@ print.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
 
 #' @export
 print_html.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
+  # check if we have weights
+  is_weighted <- isTRUE(attributes(x)$is_weighted)
+
   if (length(x) == 1) {
     print_html(x[[1]], big_mark = big_mark, ...)
   } else {
@@ -421,7 +434,7 @@ print_html.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
     insight::export_table(
       out,
       missing = "<NA>",
-      caption = "Frequency Table",
+      caption = ifelse(is_weighted, "Frequency Table (weighted)", "Frequency Table"),
       format = "html",
       group_by = "Group"
     )
@@ -431,6 +444,9 @@ print_html.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
 
 #' @export
 print_md.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
+  # check if we have weights
+  is_weighted <- isTRUE(attributes(x)$is_weighted)
+
   if (length(x) == 1) {
     print_md(x[[1]], big_mark = big_mark, ...)
   } else {
@@ -451,7 +467,7 @@ print_md.dw_data_tabulates <- function(x, big_mark = NULL, ...) {
       missing = "(NA)",
       empty_line = "-",
       format = "markdown",
-      title = "Frequency Table"
+      title = ifelse(is_weighted, "Frequency Table (weighted)", "Frequency Table")
     )
   }
 }

--- a/man/data_tabulate.Rd
+++ b/man/data_tabulate.Rd
@@ -8,7 +8,14 @@
 \usage{
 data_tabulate(x, ...)
 
-\method{data_tabulate}{default}(x, drop_levels = FALSE, name = NULL, verbose = TRUE, ...)
+\method{data_tabulate}{default}(
+  x,
+  drop_levels = FALSE,
+  weights = NULL,
+  name = NULL,
+  verbose = TRUE,
+  ...
+)
 
 \method{data_tabulate}{data.frame}(
   x,
@@ -18,6 +25,7 @@ data_tabulate(x, ...)
   regex = FALSE,
   collapse = FALSE,
   drop_levels = FALSE,
+  weights = NULL,
   verbose = TRUE,
   ...
 )
@@ -30,6 +38,9 @@ data_tabulate(x, ...)
 \item{drop_levels}{Logical, if \code{TRUE}, factor levels that do not occur in
 the data are included in the table (with frequency of zero), else unused
 factor levels are dropped from the frequency table.}
+
+\item{weights}{Optional numeric vector of weights. Must be of the same length
+as \code{x}. If \code{weights} is supplied, weighted frequencies are calculated.}
 
 \item{name}{Optional character string, which includes the name that is used
 for printing.}
@@ -125,5 +136,10 @@ data_tabulate(x, name = "Large Number")
 
 # to remove the big mark, use "print(..., big_mark = "")"
 print(data_tabulate(x), big_mark = "")
+
+# weighted frequencies
+set.seed(123)
+efc$weights <- abs(rnorm(n = nrow(efc), mean = 1, sd = 0.5))
+data_tabulate(efc$e42dep, weights = efc$weights)
 \dontshow{\}) # examplesIf}
 }

--- a/man/datawizard-package.Rd
+++ b/man/datawizard-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{datawizard-package}
 \alias{datawizard-package}
-\alias{_PACKAGE}
 \alias{datawizard}
 \title{datawizard: Easy Data Wrangling and Statistical Transformations}
 \description{

--- a/tests/testthat/_snaps/data_tabulate.md
+++ b/tests/testthat/_snaps/data_tabulate.md
@@ -1,6 +1,42 @@
 # data_tabulate, weights
 
     Code
+      print(data_tabulate(efc$e42dep, weights = efc$weights))
+    Output
+      elder's dependency (efc$e42dep) <categorical>
+      # total N=105 valid N=100 (weighted)
+      
+      Value |  N | Raw % | Valid % | Cumulative %
+      ------+----+-------+---------+-------------
+      1     |  3 |  2.86 |    3.00 |         3.00
+      2     |  4 |  3.81 |    4.00 |         7.00
+      3     | 26 | 24.76 |   26.00 |        33.00
+      4     | 67 | 63.81 |   67.00 |       100.00
+      <NA>  |  5 |  4.76 |    <NA> |         <NA>
+
+---
+
+    Code
+      print_md(data_tabulate(efc$e42dep, weights = efc$weights))
+    Output
+       [1] "Table: elder's dependency (efc$e42dep) (categorical)"
+       [2] ""                                                    
+       [3] "|Value |  N| Raw %| Valid %| Cumulative %|"          
+       [4] "|:-----|--:|-----:|-------:|------------:|"          
+       [5] "|1     |  3|  2.86|    3.00|         3.00|"          
+       [6] "|2     |  4|  3.81|    4.00|         7.00|"          
+       [7] "|3     | 26| 24.76|   26.00|        33.00|"          
+       [8] "|4     | 67| 63.81|   67.00|       100.00|"          
+       [9] "|(NA)  |  5|  4.76|    (NA)|         (NA)|"          
+      [10] "total N=105 valid N=100 (weighted)\n\n"              
+      attr(,"format")
+      [1] "pipe"
+      attr(,"class")
+      [1] "knitr_kable" "character"  
+
+---
+
+    Code
       print(data_tabulate(efc, c("e42dep", "e16sex"), collapse = TRUE, weights = efc$
         weights))
     Output

--- a/tests/testthat/_snaps/data_tabulate.md
+++ b/tests/testthat/_snaps/data_tabulate.md
@@ -1,3 +1,46 @@
+# data_tabulate, weights
+
+    Code
+      print(data_tabulate(efc, c("e42dep", "e16sex"), collapse = TRUE, weights = efc$
+        weights))
+    Output
+      # Frequency Table (weighted)
+      
+      Variable | Value |  N | Raw % | Valid % | Cumulative %
+      ---------+-------+----+-------+---------+-------------
+      e42dep   |     1 |  3 |  2.86 |    3.00 |         3.00
+               |     2 |  4 |  3.81 |    4.00 |         7.00
+               |     3 | 26 | 24.76 |   26.00 |        33.00
+               |     4 | 67 | 63.81 |   67.00 |       100.00
+               |  <NA> |  5 |  4.76 |    <NA> |         <NA>
+      ---------+-------+----+-------+---------+-------------
+      e16sex   |     1 | 50 | 47.62 |  100.00 |       100.00
+               |     2 | 55 | 52.38 |    <NA> |         <NA>
+      ------------------------------------------------------
+
+---
+
+    Code
+      print_md(data_tabulate(efc, c("e42dep", "e16sex"), weights = efc$weights))
+    Output
+       [1] "Table: Frequency Table (weighted)"                   
+       [2] ""                                                    
+       [3] "|Variable | Value|  N| Raw %| Valid %| Cumulative %|"
+       [4] "|:--------|-----:|--:|-----:|-------:|------------:|"
+       [5] "|e42dep   |     1|  3|  2.86|    3.00|         3.00|"
+       [6] "|         |     2|  4|  3.81|    4.00|         7.00|"
+       [7] "|         |     3| 26| 24.76|   26.00|        33.00|"
+       [8] "|         |     4| 67| 63.81|   67.00|       100.00|"
+       [9] "|         |  (NA)|  5|  4.76|    (NA)|         (NA)|"
+      [10] "|         |      |   |      |        |             |"
+      [11] "|e16sex   |     1| 50| 47.62|  100.00|       100.00|"
+      [12] "|         |     2| 55| 52.38|    (NA)|         (NA)|"
+      [13] "|         |      |   |      |        |             |"
+      attr(,"format")
+      [1] "pipe"
+      attr(,"class")
+      [1] "knitr_kable" "character"  
+
 # data_tabulate print
 
     Code

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -32,6 +32,29 @@ test_that("data_tabulate numeric", {
 })
 
 
+test_that("data_tabulate, weights", {
+  data(efc, package = "datawizard")
+  set.seed(123)
+  efc$weights <- abs(rnorm(n = nrow(efc), mean = 1, sd = 0.5))
+  # vector/factor
+  out1 <- data_tabulate(efc$e42dep, weights = efc$weights)
+  out2 <- data_tabulate(efc$e42dep)
+  expect_identical(out1$N, c(3, 4, 26, 67, 5))
+  expect_identical(out2$N, c(2L, 4L, 28L, 63L, 3L))
+  expect_equal(
+    out1$N,
+    round(xtabs(efc$weights ~ efc$e42dep, addNA = TRUE)),
+    ignore_attr = TRUE
+  )
+  # data frames
+  out <- data_tabulate(efc, c("e42dep", "e16sex"), weights = efc$weights)
+  expect_identical(out[[1]]$N, out1$N)
+  # mismatch of lengths
+  w <- c(efc$weights, 1)
+  expect_error(data_tabulate(efc$e42dep, weights = w), regex = "Length of weights")
+})
+
+
 test_that("data_tabulate data.frame", {
   x <- data_tabulate(efc, c("e16sex", "c172code"))
   expect_s3_class(x, "list")

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -39,8 +39,8 @@ test_that("data_tabulate, weights", {
   # vector/factor
   out1 <- data_tabulate(efc$e42dep, weights = efc$weights)
   out2 <- data_tabulate(efc$e42dep)
-  expect_identical(out1$N, c(3, 4, 26, 67, 5))
-  expect_identical(out2$N, c(2L, 4L, 28L, 63L, 3L))
+  expect_equal(out1$N, c(3, 4, 26, 67, 5), ignore_attr = TRUE)
+  expect_equal(out2$N, c(2L, 4L, 28L, 63L, 3L), ignore_attr = TRUE)
   expect_equal(
     out1$N,
     round(xtabs(efc$weights ~ efc$e42dep, addNA = TRUE)),
@@ -48,10 +48,13 @@ test_that("data_tabulate, weights", {
   )
   # data frames
   out <- data_tabulate(efc, c("e42dep", "e16sex"), weights = efc$weights)
-  expect_identical(out[[1]]$N, out1$N)
+  expect_equal(out[[1]]$N, out1$N, ignore_attr = TRUE)
   # mismatch of lengths
   w <- c(efc$weights, 1)
   expect_error(data_tabulate(efc$e42dep, weights = w), regex = "Length of weights")
+  # correct table footer
+  expect_snapshot(print(data_tabulate(efc$e42dep, weights = efc$weights)))
+  expect_snapshot(print_md(data_tabulate(efc$e42dep, weights = efc$weights)))
   # correct table caption
   expect_snapshot(print(data_tabulate(efc, c("e42dep", "e16sex"), collapse = TRUE, weights = efc$weights)))
   expect_snapshot(print_md(data_tabulate(efc, c("e42dep", "e16sex"), weights = efc$weights)))

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -51,7 +51,7 @@ test_that("data_tabulate, weights", {
   expect_equal(out[[1]]$N, out1$N, ignore_attr = TRUE)
   # mismatch of lengths
   w <- c(efc$weights, 1)
-  expect_error(data_tabulate(efc$e42dep, weights = w), regex = "Length of weights")
+  expect_error(data_tabulate(efc$e42dep, weights = w), regex = "Length of `weights`")
   # correct table footer
   expect_snapshot(print(data_tabulate(efc$e42dep, weights = efc$weights)))
   expect_snapshot(print_md(data_tabulate(efc$e42dep, weights = efc$weights)))

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -52,6 +52,9 @@ test_that("data_tabulate, weights", {
   # mismatch of lengths
   w <- c(efc$weights, 1)
   expect_error(data_tabulate(efc$e42dep, weights = w), regex = "Length of weights")
+  # correct table caption
+  expect_snapshot(print(data_tabulate(efc, c("e42dep", "e16sex"), collapse = TRUE, weights = efc$weights)))
+  expect_snapshot(print_md(data_tabulate(efc, c("e42dep", "e16sex"), weights = efc$weights)))
 })
 
 

--- a/tests/testthat/test-data_tabulate.R
+++ b/tests/testthat/test-data_tabulate.R
@@ -118,7 +118,7 @@ test_that("data_tabulate data.frame", {
 
 test_that("data_tabulate print", {
   set.seed(123)
-  x <- sample(1:3, 1e6, TRUE)
+  x <- sample.int(3, 1e6, TRUE)
   out <- data_tabulate(x, name = "Large Number")
   expect_identical(
     attributes(out),
@@ -149,7 +149,7 @@ test_that("data_tabulate print multiple", {
 
 test_that("data_tabulate big numbers", {
   set.seed(123)
-  x <- sample(1:5, size = 1e7, TRUE)
+  x <- sample.int(5, size = 1e7, TRUE)
   expect_snapshot(data_tabulate(x))
   expect_snapshot(print(data_tabulate(x), big_mark = "-"))
 })


### PR DESCRIPTION
``` r
library(datawizard)
data(efc, package = "datawizard")
set.seed(123)
efc$weights <- abs(rnorm(n = nrow(efc), mean = 1, sd = 0.5))

# unweighted
data_tabulate(efc$e42dep)
#> elder's dependency (efc$e42dep) <categorical>
#> # total N=100 valid N=97
#> 
#> Value |  N | Raw % | Valid % | Cumulative %
#> ------+----+-------+---------+-------------
#> 1     |  2 |  2.00 |    2.06 |         2.06
#> 2     |  4 |  4.00 |    4.12 |         6.19
#> 3     | 28 | 28.00 |   28.87 |        35.05
#> 4     | 63 | 63.00 |   64.95 |       100.00
#> <NA>  |  3 |  3.00 |    <NA> |         <NA>

# weighted
data_tabulate(efc$e42dep, weights = efc$weights)
#> elder's dependency (efc$e42dep) <categorical>
#> # total N=105 valid N=100
#> 
#> Value |  N | Raw % | Valid % | Cumulative %
#> ------+----+-------+---------+-------------
#> 1     |  3 |  2.86 |    3.00 |         3.00
#> 2     |  4 |  3.81 |    4.00 |         7.00
#> 3     | 26 | 24.76 |   26.00 |        33.00
#> 4     | 67 | 63.81 |   67.00 |       100.00
#> <NA>  |  5 |  4.76 |    <NA> |         <NA>
```

<sup>Created on 2024-02-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
