### PR TITLE
DOn't check type of NA values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.10.0
+Version: 0.10.0.1
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# datawizard 0.10.1
+
+CHANGES
+
+* `recode_into()` is more relaxed regarding checking the type of `NA` values.
+  If you recode into a numeric variable, and one of the recode values is `NA`,
+  you no longer need to use `NA_real_` for numeric `NA` values.
+
 # datawizard 0.10.0
 
 BREAKING CHANGES

--- a/R/recode_into.R
+++ b/R/recode_into.R
@@ -140,12 +140,22 @@ recode_into <- function(...,
   for (i in seq_len(n_params)) {
     # get type of all recode values
     if (is.null(data)) {
-      type <- typeof(.dynEval(dots[[i]][[3]], ifnotfound = NULL))
-      len_matches <- length(.dynEval(dots[[i]][[2]], ifnotfound = NULL))
+      value_type <- .dynEval(dots[[i]][[3]], ifnotfound = NULL)
+      value_length <- .dynEval(dots[[i]][[2]], ifnotfound = NULL)
     } else {
-      type <- typeof(with(data, eval(dots[[i]][[3]])))
-      len_matches <- length(with(data, eval(dots[[i]][[2]])))
+      value_type <- with(data, eval(dots[[i]][[3]]))
+      value_length <- with(data, eval(dots[[i]][[2]]))
     }
+    # if we have "NA", we don't want to check the type. Else, you cannot use
+    # "NA" for numeric recodes, but rather need to use "NA_real_", which is not
+    # user-friendly
+    if (is.na(value_type)) {
+      type <- NULL
+    } else {
+      type <- typeof(value_type)
+    }
+    len_matches <- length(value_length)
+    # save type and length of recode values
     all_recodes <- c(all_recodes, type)
     all_same_length <- c(all_same_length, len_matches)
   }

--- a/tests/testthat/test-recode_into.R
+++ b/tests/testthat/test-recode_into.R
@@ -136,7 +136,7 @@ test_that("recode_into, works inside functions", {
   test <- function() {
     set.seed(123)
     d <- data.frame(
-      x = sample(1:5, 30, TRUE),
+      x = sample.int(5, 30, TRUE),
       y = sample(letters[1:5], 30, TRUE),
       stringsAsFactors = FALSE
     )
@@ -257,4 +257,19 @@ test_that("recode_into, make sure recode works with missing in original variable
       0, 2, 2, 2, 2, 0, 0, 0, 2, 2, 2, 0
     )
   )
+})
+
+test_that("recode_into, NA doesn't need to be of exact type", {
+  data(mtcars)
+  x1 <- recode_into(
+    mpg > 10 ~ 1,
+    gear == 5 ~ NA_real_,
+    data = mtcars
+  )
+  x2 <- recode_into(
+    mpg > 10 ~ 1,
+    gear == 5 ~ NA,
+    data = mtcars
+  )
+  expect_identical(x1, x2)
 })


### PR DESCRIPTION
``` r
library(datawizard)
data(mtcars)
x1 <- recode_into(
  mpg > 10 ~ 1,
  gear == 5 ~ NA_real_,
  data = mtcars
)
#> Warning: Several recode patterns apply to the same cases. Some of the already
#>   recoded cases will be overwritten with new values again (e.g. pattern 2
#>   overwrites the former recode of case 27).
#>   Please check if this is intentional!
# this didn't work before
x2 <- recode_into(
  mpg > 10 ~ 1,
  gear == 5 ~ NA,
  data = mtcars
)
#> Warning: Several recode patterns apply to the same cases. Some of the already
#>   recoded cases will be overwritten with new values again (e.g. pattern 2
#>   overwrites the former recode of case 27).
#>   Please check if this is intentional!
identical(x1, x2)
#> [1] TRUE
```

<sup>Created on 2024-05-04 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
