### PR TITLE
Remove Twitter-tag from Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,19 +4,19 @@ Title: Easy Data Wrangling and Statistical Transformations
 Version: 0.12.3.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
-           comment = c(ORCID = "0000-0003-1995-6531", Twitter = "@patilindrajeets")),
+           comment = c(ORCID = "0000-0003-1995-6531")),
     person("Etienne", "Bacher", , "etienne.bacher@protonmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-9271-5075")),
     person("Dominique", "Makowski", , "dom.makowski@gmail.com", role = "aut",
-           comment = c(ORCID = "0000-0001-5375-9967", Twitter = "@Dom_Makowski")),
+           comment = c(ORCID = "0000-0001-5375-9967")),
     person("Daniel", "Lüdecke", , "d.luedecke@uke.de", role = "aut",
-           comment = c(ORCID = "0000-0002-8895-3206", Twitter = "@strengejacke")),
+           comment = c(ORCID = "0000-0002-8895-3206")),
     person("Mattan S.", "Ben-Shachar", , "matanshm@post.bgu.ac.il", role = "aut",
            comment = c(ORCID = "0000-0002-4287-4801")),
     person("Brenton M.", "Wiernik", , "brenton@wiernik.org", role = "aut",
-           comment = c(ORCID = "0000-0001-9560-6336", Twitter = "@bmwiernik")),
+           comment = c(ORCID = "0000-0001-9560-6336")),
     person("Rémi", "Thériault", , "remi.theriault@mail.mcgill.ca", role = "ctb",
-           comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")),
+           comment = c(ORCID = "0000-0003-4315-6788")),
     person("Thomas J.", "Faulkenberry", , "faulkenberry@tarleton.edu", role = "rev"),
     person("Robert", "Garrett", , "rcg4@illinois.edu", role = "rev")
   )


### PR DESCRIPTION
See discussion in https://github.com/easystats/insight/pull/936.

This NOTE was already on win-builder, but I didn't realize. I now uploaded _insight_ to win-builder again, removing Twitter IDs. If this resolves the NOTE, we can merge this PR (it's likely to cause the same problems with _datawizard_ then).