### PR TITLE
Do not error when bootstrapping CIs if sample is too sparse

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.13.0
+Version: 0.13.0.1
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 BUG FIXES
 
-* `describe_distribution()` no longer errors if sample was too sparse to compute
+* `describe_distribution()` no longer errors if the sample was too sparse to compute
   CIs. Instead, it warns the user and returns `NA` (#550).
 
 # datawizard 0.13.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# datawizard (development)
+
+BUG FIXES
+
+* `describe_distribution()` no longer errors if sample was too sparse to compute
+  CIs. Instead, it warns the user and returns `NA` (#550).
+
 # datawizard 0.13.0
 
 BREAKING CHANGES

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -186,7 +186,8 @@ describe_distribution.numeric <- function(x,
   # Confidence Intervals
   if (!is.null(ci)) {
     insight::check_if_installed("boot")
-    results <- tryCatch({
+    results <- tryCatch(
+      {
         boot::boot(
           data = x,
           statistic = .boot_distribution,
@@ -200,7 +201,7 @@ describe_distribution.numeric <- function(x,
           insight::format_warning(
             "When bootstrapping CIs, sample was too sparse to find TD. Returning NA for CIs."
           )
-          return(list(t = c(NA_real_, NA_real_)))
+          list(t = c(NA_real_, NA_real_))
         }
       }
     )

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -186,11 +186,23 @@ describe_distribution.numeric <- function(x,
   # Confidence Intervals
   if (!is.null(ci)) {
     insight::check_if_installed("boot")
-    results <- boot::boot(
-      data = x,
-      statistic = .boot_distribution,
-      R = iterations,
-      centrality = centrality
+    results <- tryCatch({
+        boot::boot(
+          data = x,
+          statistic = .boot_distribution,
+          R = iterations,
+          centrality = centrality
+        )
+      },
+      error = function(e) {
+        msg <- conditionMessage(e)
+        if (!is.null(msg) && msg == "sample is too sparse to find TD") {
+          insight::format_warning(
+            "When bootstrapping CIs, sample was too sparse to find TD. Returning NA for CIs."
+          )
+          return(list(t = c(NA_real_, NA_real_)))
+        }
+      }
     )
     out_ci <- bayestestR::ci(results$t, ci = ci, verbose = FALSE)
     out <- cbind(out, data.frame(CI_low = out_ci$CI_low[1], CI_high = out_ci$CI_high[1]))

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -290,7 +290,7 @@ test_that("describe_distribution formatting", {
 # other -----------------------------------
 
 test_that("return NA in CI if sample is too sparse", {
-  skip_if_not_install("bayestestR")
+  skip_if_not_installed("bayestestR")
   set.seed(123456)
   expect_warning(
     res <- describe_distribution(mtcars[mtcars$cyl == "6", ], wt, centrality = "map", ci = 0.95), #nolint

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -293,7 +293,7 @@ test_that("return NA in CI if sample is too sparse", {
   skip_if_not_installed("bayestestR")
   set.seed(123456)
   expect_warning(
-    res <- describe_distribution(mtcars[mtcars$cyl == "6", ], wt, centrality = "map", ci = 0.95), #nolint
+    res <- describe_distribution(mtcars[mtcars$cyl == "6", ], wt, centrality = "map", ci = 0.95), # nolint
     "When bootstrapping CIs, sample was too sparse to find TD"
   )
   expect_identical(res$CI_low, NA)

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -286,3 +286,15 @@ test_that("describe_distribution formatting", {
   x <- describe_distribution(iris$Sepal.Width, quartiles = TRUE)
   expect_snapshot(format(x))
 })
+
+# other -----------------------------------
+
+test_that("return NA in CI if sample is too sparse", {
+  set.seed(123456)
+  expect_warning(
+    res <- describe_distribution(mtcars[mtcars$cyl=="6",], wt, centrality = "map", ci = 0.95),
+    "When bootstrapping CIs, sample was too sparse to find TD"
+  )
+  expect_identical(res$CI_low, NA)
+  expect_identical(res$CI_high, NA)  
+})

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -292,9 +292,9 @@ test_that("describe_distribution formatting", {
 test_that("return NA in CI if sample is too sparse", {
   set.seed(123456)
   expect_warning(
-    res <- describe_distribution(mtcars[mtcars$cyl=="6",], wt, centrality = "map", ci = 0.95),
+    res <- describe_distribution(mtcars[mtcars$cyl == "6", ], wt, centrality = "map", ci = 0.95), #nolint
     "When bootstrapping CIs, sample was too sparse to find TD"
   )
   expect_identical(res$CI_low, NA)
-  expect_identical(res$CI_high, NA)  
+  expect_identical(res$CI_high, NA)
 })

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -290,6 +290,7 @@ test_that("describe_distribution formatting", {
 # other -----------------------------------
 
 test_that("return NA in CI if sample is too sparse", {
+  skip_if_not_install("bayestestR")
   set.seed(123456)
   expect_warning(
     res <- describe_distribution(mtcars[mtcars$cyl == "6", ], wt, centrality = "map", ci = 0.95), #nolint


### PR DESCRIPTION
Close #540

``` r
library(datawizard)

set.seed(123456)
describe_distribution(mtcars[mtcars$cyl=="6",], wt, centrality = "map", ci = 0.95)
#> Warning: When bootstrapping CIs, sample was too sparse to find TD. Returning NA
#>   for CIs.
#> Variable |  MAP |  IQR | 95% CI |        Range | Skewness | Kurtosis | n | n_Missing
#> ------------------------------------------------------------------------------------
#> wt       | 3.43 | 0.67 |        | [2.62, 3.46] |    -0.36 |    -2.08 | 7 |         0
```

<sup>Created on 2024-10-07 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>