### PR TITLE
set `trust = TRUE` also for RData files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.13.0.7
+Version: 0.13.0.8
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@ CHANGES
 
 * New function `row_count()`, to count specific values row-wise.
 
+* `data_read()` no longer shows warning about forthcoming breaking changes
+  in upstream packages when reading `.RData` files.
+
 BUG FIXES
 
 * `describe_distribution()` no longer errors if the sample was too sparse to compute

--- a/R/data_read.R
+++ b/R/data_read.R
@@ -296,7 +296,7 @@ data_read <- function(path,
   # set up arguments. for RDS, we set trust = TRUE, to avoid warnings
   rio_args <- list(file = path)
   # check if we have RDS, and if so, add trust = TRUE
-  if (file_type == "rds") {
+  if (file_type %in% c("rds", "rdata")) {
     rio_args$trust <- TRUE
   }
   out <- do.call(rio::import, c(rio_args, list(...)))

--- a/R/data_read.R
+++ b/R/data_read.R
@@ -161,7 +161,7 @@ data_read <- function(path,
   # user may decide whether we automatically detect variable type or not
   if (isTRUE(convert_factors)) {
     if (verbose) {
-      msg <- "Variables where all values have associated labels are now converted into factors. If this is not intended, use `convert_factors = FALSE`."
+      msg <- "Variables where all values have associated labels are now converted into factors. If this is not intended, use `convert_factors = FALSE`." # nolint
       insight::format_alert(msg)
     }
     x[] <- lapply(x, function(i) {

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -161,7 +161,7 @@ test_that("data_read - no warning for RData", {
   withr::with_tempfile("temp_file", fileext = ".RData", code = {
     data(mtcars)
     save(mtcars, file = temp_file)
-    expect_silent(data_read(temp_file, verbose = FALSE, trust = TRUE))
+    expect_silent(data_read(temp_file, verbose = FALSE))
   })
 })
 

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -154,6 +154,19 @@ test_that("data_read - RDS file, matrix, coercible", {
 })
 
 
+
+# RData -----------------------------------
+
+test_that("data_read - no warning for RData", {
+  withr::with_tempfile("temp_file", fileext = ".RData", code = {
+    data(mtcars)
+    save(mtcars, file = temp_file)
+    expect_silent(data_read(temp_file, verbose = FALSE, trust = TRUE))
+  })
+})
+
+
+
 # SPSS file -----------------------------------
 
 test_that("data_read - SPSS file", {


### PR DESCRIPTION
We had this already for `rds`, but forgot for `RData`.