### PR TITLE
`data_read()` preserves class for rds files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.13.0.8
+Version: 0.13.0.9
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,7 @@ BUG FIXES
   CIs. Instead, it warns the user and returns `NA` (#550).
 
 * `data_read()` preserves variable types when importing files from `rds` or
-  `rdata` format.
+  `rdata` format (#558).
 
 # datawizard 0.13.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@ BUG FIXES
 * `describe_distribution()` no longer errors if the sample was too sparse to compute
   CIs. Instead, it warns the user and returns `NA` (#550).
 
-* `data_read()` reserves variable types when importing files from `rds` or
+* `data_read()` preserves variable types when importing files from `rds` or
   `rdata` format.
 
 # datawizard 0.13.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@ BUG FIXES
 * `describe_distribution()` no longer errors if the sample was too sparse to compute
   CIs. Instead, it warns the user and returns `NA` (#550).
 
+* `data_read()` reserves variable types when importing files from `rds` or
+  `rdata` format.
+
 # datawizard 0.13.0
 
 BREAKING CHANGES

--- a/R/data_read.R
+++ b/R/data_read.R
@@ -15,15 +15,16 @@
 #' for SAS data files.
 #' @param encoding The character encoding used for the file. Usually not needed.
 #' @param convert_factors If `TRUE` (default), numeric variables, where all
-#' values have a value label, are assumed to be categorical and converted
-#' into factors. If `FALSE`, no variable types are guessed and no conversion
-#' of numeric variables into factors will be performed. See also section
-#' 'Differences to other packages'. For `data_write()`, this argument only
-#' applies to the text (e.g. `.txt` or `.csv`) or spreadsheet file formats (like
-#' `.xlsx`). Converting to factors might be useful for these formats because
-#' labelled numeric variables are then converted into factors and exported as
-#' character columns - else, value labels would be lost and only numeric values
-#' are written to the file.
+#' values have a value label, are assumed to be categorical and converted into
+#' factors. If `FALSE`, no variable types are guessed and no conversion of
+#' numeric variables into factors will be performed. For `data_read()`, this
+#' argument only applies to file types with *labelled data*, e.g. files from
+#' SPSS, SAS or Stata. See also section 'Differences to other packages'. For
+#' `data_write()`, this argument only applies to the text (e.g. `.txt` or
+#' `.csv`) or spreadsheet file formats (like `.xlsx`). Converting to factors
+#' might be useful for these formats because labelled numeric variables are then
+#' converted into factors and exported as character columns - else, value labels
+#' would be lost and only numeric values are written to the file.
 #' @param verbose Toggle warnings and messages.
 #' @param ... Arguments passed to the related `read_*()` or `write_*()` functions.
 #'
@@ -65,12 +66,13 @@
 #' @section Differences to other packages that read foreign data formats:
 #' `data_read()` is most comparable to `rio::import()`. For data files from
 #' SPSS, SAS or Stata, which support labelled data, variables are converted into
-#' their most appropriate type. The major difference to `rio::import()` is that
-#' `data_read()` automatically converts fully labelled numeric variables into
-#' factors, where imported value labels will be set as factor levels. If a
-#' numeric variable has _no_ value labels or less value labels than values, it
-#' is not converted to factor. In this case, value labels are preserved as
-#' `"labels"` attribute. Character vectors are preserved. Use
+#' their most appropriate type. The major difference to `rio::import()` is for
+#' data files from SPSS, SAS, or Stata, i.e. file types that support
+#' *labelled data*. `data_read()` automatically converts fully labelled numeric
+#' variables into factors, where imported value labels will be set as factor
+#' levels. If a numeric variable has _no_ value labels or less value labels than
+#' values, it is not converted to factor. In this case, value labels are
+#' preserved as `"labels"` attribute. Character vectors are preserved. Use
 #' `convert_factors = FALSE` to remove the automatic conversion of numeric
 #' variables to factors.
 #'
@@ -105,7 +107,7 @@ data_read <- function(path,
     por = .read_spss(path, encoding, convert_factors, verbose, ...),
     dta = .read_stata(path, encoding, convert_factors, verbose, ...),
     sas7bdat = .read_sas(path, path_catalog, encoding, convert_factors, verbose, ...),
-    .read_unknown(path, file_type, convert_factors, verbose, ...)
+    .read_unknown(path, file_type, verbose, ...)
   )
 
   # tell user about empty columns
@@ -171,42 +173,35 @@ data_read <- function(path,
         value_labels <- attr(i, "labels", exact = TRUE)
         variable_labels <- attr(i, "label", exact = TRUE)
 
-        # Only process if we have value labels - if no value labels present
-        # the following code falls back to coercing to numeric. Since this
-        # function is also called for "unknown" file types, all imported data
-        # is converted to numeric for non-labelled data, which is not intended,
-        # for instance for .rds files
-        if (!is.null(value_labels) && length(value_labels)) {
-          # filter, so only matching value labels remain
-          value_labels <- value_labels[value_labels %in% unique(i)]
+        # filter, so only matching value labels remain
+        value_labels <- value_labels[value_labels %in% unique(i)]
 
-          # guess variable type
-          if (is.character(i)) {
-            # we need this to drop haven-specific class attributes
-            i <- as.character(i)
-          } else if (!is.null(value_labels) && length(value_labels) == insight::n_unique(i)) {
-            # if all values are labelled, we assume factor. Use labels as levels
-            if (is.numeric(i)) {
-              i <- factor(i, labels = names(value_labels))
-            } else {
-              i <- factor(as.character(i), labels = names(value_labels))
-            }
-            value_labels <- NULL
-            attr(i, "converted_to_factor") <- TRUE
+        # guess variable type
+        if (is.character(i)) {
+          # we need this to drop haven-specific class attributes
+          i <- as.character(i)
+        } else if (!is.null(value_labels) && length(value_labels) == insight::n_unique(i)) {
+          # if all values are labelled, we assume factor. Use labels as levels
+          if (is.numeric(i)) {
+            i <- factor(i, labels = names(value_labels))
           } else {
-            # else, fall back to numeric
-            i <- as.numeric(i)
+            i <- factor(as.character(i), labels = names(value_labels))
           }
-
-          # drop unused value labels
-          value_labels <- value_labels[value_labels %in% unique(i)]
-          if (length(value_labels) > 0L) {
-            attr(i, "labels") <- value_labels
-          }
-
-          # add back variable label
-          attr(i, "label") <- variable_labels
+          value_labels <- NULL
+          attr(i, "converted_to_factor") <- TRUE
+        } else {
+          # else, fall back to numeric or factor
+          i <- as.numeric(i)
         }
+
+        # drop unused value labels
+        value_labels <- value_labels[value_labels %in% unique(i)]
+        if (length(value_labels) > 0L) {
+          attr(i, "labels") <- value_labels
+        }
+
+        # add back variable label
+        attr(i, "label") <- variable_labels
       }
       i
     })
@@ -295,7 +290,7 @@ data_read <- function(path,
 }
 
 
-.read_unknown <- function(path, file_type, convert_factors, verbose, ...) {
+.read_unknown <- function(path, file_type, verbose, ...) {
   insight::check_if_installed("rio", reason = paste0("to read files of type '", file_type, "'"))
   if (verbose) {
     insight::format_alert("Reading data...")
@@ -324,6 +319,5 @@ data_read <- function(path,
     }
     out <- tmp
   }
-
-  .post_process_imported_data(out, convert_factors, verbose)
+  out
 }

--- a/man/data_read.Rd
+++ b/man/data_read.Rd
@@ -33,15 +33,16 @@ for SAS data files.}
 \item{encoding}{The character encoding used for the file. Usually not needed.}
 
 \item{convert_factors}{If \code{TRUE} (default), numeric variables, where all
-values have a value label, are assumed to be categorical and converted
-into factors. If \code{FALSE}, no variable types are guessed and no conversion
-of numeric variables into factors will be performed. See also section
-'Differences to other packages'. For \code{data_write()}, this argument only
-applies to the text (e.g. \code{.txt} or \code{.csv}) or spreadsheet file formats (like
-\code{.xlsx}). Converting to factors might be useful for these formats because
-labelled numeric variables are then converted into factors and exported as
-character columns - else, value labels would be lost and only numeric values
-are written to the file.}
+values have a value label, are assumed to be categorical and converted into
+factors. If \code{FALSE}, no variable types are guessed and no conversion of
+numeric variables into factors will be performed. For \code{data_read()}, this
+argument only applies to file types with \emph{labelled data}, e.g. files from
+SPSS, SAS or Stata. See also section 'Differences to other packages'. For
+\code{data_write()}, this argument only applies to the text (e.g. \code{.txt} or
+\code{.csv}) or spreadsheet file formats (like \code{.xlsx}). Converting to factors
+might be useful for these formats because labelled numeric variables are then
+converted into factors and exported as character columns - else, value labels
+would be lost and only numeric values are written to the file.}
 
 \item{verbose}{Toggle warnings and messages.}
 
@@ -118,12 +119,13 @@ versions, use \code{compress = "none"}, for example
 
 \code{data_read()} is most comparable to \code{rio::import()}. For data files from
 SPSS, SAS or Stata, which support labelled data, variables are converted into
-their most appropriate type. The major difference to \code{rio::import()} is that
-\code{data_read()} automatically converts fully labelled numeric variables into
-factors, where imported value labels will be set as factor levels. If a
-numeric variable has \emph{no} value labels or less value labels than values, it
-is not converted to factor. In this case, value labels are preserved as
-\code{"labels"} attribute. Character vectors are preserved. Use
+their most appropriate type. The major difference to \code{rio::import()} is for
+data files from SPSS, SAS, or Stata, i.e. file types that support
+\emph{labelled data}. \code{data_read()} automatically converts fully labelled numeric
+variables into factors, where imported value labels will be set as factor
+levels. If a numeric variable has \emph{no} value labels or less value labels than
+values, it is not converted to factor. In this case, value labels are
+preserved as \code{"labels"} attribute. Character vectors are preserved. Use
 \code{convert_factors = FALSE} to remove the automatic conversion of numeric
 variables to factors.
 }

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -141,15 +141,38 @@ test_that("data_read - RDS file, matrix, coercible", {
     httr::stop_for_status(request)
     writeBin(httr::content(request, type = "raw"), temp_file)
 
-    expect_message(expect_message(expect_message({
+    expect_message({
       d <- data_read(
         temp_file,
         verbose = TRUE
       )
-    })), regex = "0 out of 5")
+    })
 
     expect_s3_class(d, "data.frame")
     expect_identical(dim(d), c(2L, 5L))
+  })
+})
+
+
+
+# RDS file, preserve class /types -----------------------------------
+
+test_that("data_read - RDS file, preserve class", {
+  withr::with_tempfile("temp_file", fileext = ".rds", code = {
+    request <- httr::GET("https://raw.github.com/easystats/circus/main/data/hiv.rds")
+    httr::stop_for_status(request)
+    writeBin(httr::content(request, type = "raw"), temp_file)
+
+    d <- data_read(temp_file)
+    expect_s3_class(d, "data.frame")
+    expect_identical(
+      sapply(d, class),
+      c(
+        village = "integer", outcome = "integer", distance = "numeric",
+        amount = "numeric", incentive = "integer", age = "integer",
+        hiv2004 = "integer", agecat = "factor"
+      )
+    )
   })
 })
 


### PR DESCRIPTION
Need to add tests.
Behaviour of  older datawizard versions (see column `agecat`):

``` r
d <- datawizard::data_read("https://github.com/vincentarelbundock/marginaleffects/raw/refs/heads/main/vignettes/chapters/data/hiv.rds")
#> Reading data...
#> Variables where all values have associated labels are now converted into
#>   factors. If this is not intended, use `convert_factors = FALSE`.
#> 0 out of 8 variables were fully labelled and converted into factors.
str(d)
#> 'data.frame':    2884 obs. of  8 variables:
#>  $ village  : num  43 117 2 6 11 14 15 25 37 100 ...
#>  $ outcome  : num  1 0 0 0 0 0 1 0 1 0 ...
#>  $ distance : num  0.549 0.84 3.342 2.323 1.386 ...
#>  $ amount   : num  0 0 0 0 0 0 0 0 0 0 ...
#>  $ incentive: num  0 0 0 0 0 0 0 0 0 0 ...
#>  $ age      : num  14 14 15 15 15 15 15 15 15 15 ...
#>  $ hiv2004  : num  0 0 0 0 0 0 0 0 0 0 ...
#>  $ agecat   : num  1 1 1 1 1 1 1 1 1 1 ...
#>  - attr(*, ".internal.selfref")=<externalptr>
```

new behaviour

``` r
d <- datawizard::data_read("https://github.com/vincentarelbundock/marginaleffects/raw/refs/heads/main/vignettes/chapters/data/hiv.rds")
#> Reading data...
str(d)
#> 'data.frame':    2884 obs. of  8 variables:
#>  $ village  : int  43 117 2 6 11 14 15 25 37 100 ...
#>  $ outcome  : int  1 0 0 0 0 0 1 0 1 0 ...
#>  $ distance : num  0.549 0.84 3.342 2.323 1.386 ...
#>  $ amount   : num  0 0 0 0 0 0 0 0 0 0 ...
#>  $ incentive: int  0 0 0 0 0 0 0 0 0 0 ...
#>  $ age      : int  14 14 15 15 15 15 15 15 15 15 ...
#>  $ hiv2004  : int  0 0 0 0 0 0 0 0 0 0 ...
#>  $ agecat   : Factor w/ 3 levels "<18","18-35",..: 1 1 1 1 1 1 1 1 1 1 ...
#>  - attr(*, ".internal.selfref")=<externalptr>
```

<sup>Created on 2024-10-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
