### PR TITLE
Warn user for invalid formula

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.13.0.12
+Version: 0.13.0.13
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/R/standardize.models.R
+++ b/R/standardize.models.R
@@ -79,7 +79,10 @@ standardize.default <- function(x,
   }
 
   # check model formula. Some notations don't work when standardizing data
-  insight::formula_ok(x, verbose = verbose)
+  if (!insight::formula_ok(x, verbose = verbose)) {
+    insight::format_alert(insight::color_text("Model cannot be standardized.", "red"))
+    return(x)
+  }
 
   data_std <- NULL # needed to avoid note
   .standardize_models(x,

--- a/R/standardize.models.R
+++ b/R/standardize.models.R
@@ -78,6 +78,9 @@ standardize.default <- function(x,
     return(x)
   }
 
+  # check model formula. Some notations don't work when standardizing data
+  insight::formula_ok(x, verbose = verbose)
+
   data_std <- NULL # needed to avoid note
   .standardize_models(x,
     robust = robust, two_sd = two_sd,

--- a/R/standardize.models.R
+++ b/R/standardize.models.R
@@ -79,10 +79,12 @@ standardize.default <- function(x,
   }
 
   # check model formula. Some notations don't work when standardizing data
-  if (!insight::formula_ok(x, verbose = verbose)) {
-    insight::format_alert(insight::color_text("Model cannot be standardized.", "red"))
-    return(x)
-  }
+  insight::formula_ok(
+    x,
+    action = "error",
+    prefix_msg = "Model cannot be standardized.",
+    verbose = verbose
+  )
 
   data_std <- NULL # needed to avoid note
   .standardize_models(x,

--- a/tests/testthat/test-standardize_models.R
+++ b/tests/testthat/test-standardize_models.R
@@ -42,14 +42,15 @@ test_that("standardize | problematic formulas", {
 
   colnames(mtcars)[1] <- "1_mpg"
   m <- lm(`1_mpg` ~ hp, data = mtcars)
-  expect_message(expect_warning(standardise(m), regex = "Looks like"))
+  expect_error(standardise(m), regex = "Looks like")
 
-  data(mtcars)
-  m <- lm(mtcars$mpg ~ mtcars$hp)
-  expect_message(expect_warning(standardise(m), regex = "model formulas"))
+  # works interactive only
+  # data(mtcars)
+  # m <- lm(mtcars$mpg ~ mtcars$hp)
+  # expect_error(standardise(m), regex = "model formulas")
 
   m <- lm(mtcars[, 1] ~ hp, data = mtcars)
-  expect_message(expect_warning(standardise(m), regex = "indexed data"))
+  expect_error(standardise(m), regex = "indexed data")
 })
 
 
@@ -228,15 +229,14 @@ test_that("standardize non-Gaussian response", {
 # variables evaluated in the environment $$$ ------------------------------
 test_that("variables evaluated in the environment", {
   m <- lm(mtcars$mpg ~ mtcars$cyl + am, data = mtcars)
-  w <- capture_warnings(standardize(m))
-  expect_true(any(grepl("mtcars$mpg", w, fixed = TRUE)))
+  w <- capture_error(standardize(m))
+  expect_true(any(grepl("Using `$`", w, fixed = TRUE)))
 
   ## Note:
   # No idea why this is suddenly not giving a warning on older R versions.
   m <- lm(mtcars$mpg ~ mtcars$cyl + mtcars$am, data = mtcars)
-  warns <- capture_warnings(standardize(m))
-  expect_true(any(grepl("mtcars$mpg", warns, fixed = TRUE)))
-  expect_true(any(grepl("No variables", warns, fixed = TRUE)))
+  w <- capture_error(standardize(m))
+  expect_true(any(grepl("Using `$`", w, fixed = TRUE)))
 })
 
 

--- a/tests/testthat/test-standardize_models.R
+++ b/tests/testthat/test-standardize_models.R
@@ -31,6 +31,28 @@ test_that("standardize | errors", {
 })
 
 
+test_that("standardize | problematic formulas", {
+  data(mtcars)
+  m <- lm(mpg ~ hp, data = mtcars)
+  expect_equal(
+    coef(standardise(m)),
+    c(`(Intercept)` = -3.14935717633686e-17, hp = -0.776168371826586),
+    tolerance = 1e-4
+  )
+
+  colnames(mtcars)[1] <- "1_mpg"
+  m <- lm(`1_mpg` ~ hp, data = mtcars)
+  expect_message(expect_warning(standardise(m), regex = "Looks like"))
+
+  data(mtcars)
+  m <- lm(mtcars$mpg ~ mtcars$hp)
+  expect_message(expect_warning(standardise(m), regex = "model formulas"))
+
+  m <- lm(mtcars[, 1] ~ hp, data = mtcars)
+  expect_message(expect_warning(standardise(m), regex = "indexed data"))
+})
+
+
 # Transformations ---------------------------------------------------------
 test_that("transformations", {
   skip_if_not_installed("effectsize")


### PR DESCRIPTION
The message when standardizing failed due to "problematic formulas" was not always clear. Now it should be clearer to users why model cannot be standardized.
 Inspired by this SO post: https://stackoverflow.com/questions/79207876/variable-names-and-easystats-reports

``` r
data(mtcars)
m <- lm(mpg ~ hp, data = mtcars)
datawizard::standardise(m)
#> 
#> Call:
#> lm(formula = mpg ~ hp, data = data_std)
#> 
#> Coefficients:
#> (Intercept)           hp  
#>  -3.149e-17   -7.762e-01

colnames(mtcars)[1] <- "1_mpg"
m <- lm(`1_mpg` ~ hp, data = mtcars)
datawizard::standardise(m)
#> Warning: Looks like you are using invalid syntactically variables names, quoted
#>   in backticks: `1_mpg`. This may result in unexpected behaviour. Please
#>   rename your variables (e.g., `X1_mpg` instead of `1_mpg`) and fit the
#>   model again.
#> Model cannot be standardized.
#> 
#> Call:
#> lm(formula = `1_mpg` ~ hp, data = mtcars)
#> 
#> Coefficients:
#> (Intercept)           hp  
#>    30.09886     -0.06823

data(mtcars)
m <- lm(mtcars$mpg ~ mtcars$hp)
datawizard::standardise(m)
#> Warning: Using `$` in model formulas can produce unexpected results. Specify your
#>   model using the `data` argument instead.
#>   Try: mpg ~ hp, data = mtcars
#> Model cannot be standardized.
#> 
#> Call:
#> lm(formula = mtcars$mpg ~ mtcars$hp)
#> 
#> Coefficients:
#> (Intercept)    mtcars$hp  
#>    30.09886     -0.06823

m <- lm(mtcars[, 1] ~ hp, data = mtcars)
datawizard::standardise(m)
#> Warning: Using indexed data frames, such as `df[, 5]`, as model response can
#>   produce unexpected results. Specify your model using the literal name of
#>   the response variable instead.
#> Model cannot be standardized.
#> 
#> Call:
#> lm(formula = mtcars[, 1] ~ hp, data = mtcars)
#> 
#> Coefficients:
#> (Intercept)           hp  
#>    30.09886     -0.06823
```

<sup>Created on 2024-11-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
