### PR TITLE
Allow glue-styled pattern for `data_rename()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 0.13.0.13
+Version: 0.13.0.14
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ CHANGES
 * `data_modify()` now recognizes `n()`, for example to create an index for data
   groups with `1:n()` (#535).
 
-* The `replacement` argument in `data_rename()` now supports curl-styled
+* The `replacement` argument in `data_rename()` now supports glue-styled
   tokens  (#563).
 
 BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,8 +19,11 @@ CHANGES
 * `data_read()` no longer shows warning about forthcoming breaking changes
   in upstream packages when reading `.RData` files.
 
-* `data_modify()` now recognizes `n()`, for example to create an index for data groups
-  with `1:n()` (#535).
+* `data_modify()` now recognizes `n()`, for example to create an index for data
+  groups with `1:n()` (#535).
+
+* The `replacement` argument in `data_rename()` now supports curl-styled
+  tokens  (#563).
 
 BUG FIXES
 

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -66,12 +66,16 @@
 #' head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
 #' head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
 #' @seealso
-#' - Functions to rename stuff: [data_rename()], [data_rename_rows()], [data_addprefix()], [data_addsuffix()]
-#' - Functions to reorder or remove columns: [data_reorder()], [data_relocate()], [data_remove()]
-#' - Functions to reshape, pivot or rotate data frames: [data_to_long()], [data_to_wide()], [data_rotate()]
+#' - Functions to rename stuff: [data_rename()], [data_rename_rows()],
+#'   [data_addprefix()], [data_addsuffix()]
+#' - Functions to reorder or remove columns: [data_reorder()], [data_relocate()],
+#'   [data_remove()]
+#' - Functions to reshape, pivot or rotate data frames: [data_to_long()],
+#'   [data_to_wide()], [data_rotate()]
 #' - Functions to recode data: [rescale()], [reverse()], [categorize()],
 #'   [recode_values()], [slide()]
-#' - Functions to standardize, normalize, rank-transform: [center()], [standardize()], [normalize()], [ranktransform()], [winsorize()]
+#' - Functions to standardize, normalize, rank-transform: [center()], [standardize()],
+#'   [normalize()], [ranktransform()], [winsorize()]
 #' - Split and merge data frames: [data_partition()], [data_merge()]
 #' - Functions to find or select columns: [data_select()], [extract_column_names()]
 #' - Functions to filter rows: [data_match()], [data_filter()]

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -23,7 +23,7 @@
 #'   - A character vector that indicates the new names of the columns selected
 #'     in `pattern`. `pattern` and `replacement` must be of the same length.
 #'   - `NULL`, in which case columns are numbered in sequential order.
-#'   - A string (i.e. character vector of length 1) with a "curl" styled pattern.
+#'   - A string (i.e. character vector of length 1) with a "glue" styled pattern.
 #'     Currently supported tokens are `{col}` and `{n}`. `{col}` will be replaced
 #'     by the column name, i.e. the corresponding value in `pattern`. `{n}` will
 #'     be replaced by the number of the variable that is replaced. For instance,
@@ -62,7 +62,7 @@
 #' # Change all
 #' head(data_rename(iris, replacement = paste0("Var", 1:5)))
 #'
-#' # Use curl-styled patterns
+#' # Use glue-styled patterns
 #' head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
 #' head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
 #' @seealso
@@ -146,8 +146,8 @@ data_rename <- function(data,
     }
   }
 
-  # check if we have "curl" styled replacement-string
-  curl_style <- length(replacement) == 1 &&
+  # check if we have "glue" styled replacement-string
+  glue_style <- length(replacement) == 1 &&
     grepl("{", replacement, fixed = TRUE) &&
     length(pattern) > 1
 
@@ -158,7 +158,7 @@ data_rename <- function(data,
         length(replacement) - length(pattern), " names of `replacement` are not used."
       )
     )
-  } else if (length(replacement) < length(pattern) && verbose && !curl_style) {
+  } else if (length(replacement) < length(pattern) && verbose && !glue_style) {
     insight::format_alert(
       paste0(
         "There are more names in `pattern` than in `replacement`. The last ",
@@ -167,9 +167,9 @@ data_rename <- function(data,
     )
   }
 
-  # if we have curl-styled replacement-string, create replacement pattern now
-  if (curl_style) {
-    replacement <- .curl_replacement(pattern, replacement)
+  # if we have glue-styled replacement-string, create replacement pattern now
+  if (glue_style) {
+    replacement <- .glue_replacement(pattern, replacement)
   }
 
   for (i in seq_along(pattern)) {
@@ -201,8 +201,8 @@ data_rename <- function(data,
 }
 
 
-.curl_replacement <- function(pattern, replacement) {
-  # this function replaces "curl" tokens into their related
+.glue_replacement <- function(pattern, replacement) {
+  # this function replaces "glue" tokens into their related
   # real names/values. Currently, following tokens are accepted:
   # - {col}: replacement is the name of the column (inidcated in "pattern")
   # - {n}: replacement is the number of the variable out of n, that should be renamed

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -30,7 +30,7 @@
 #'     - `{n}` will be replaced by the number of the variable that is replaced.
 #'     - `{letter}` will be replaced by alphabetical letters in sequential order.
 #'       If more than 26 letters are required, letters are repeated, but have
-#'       seqential numeric indices (e.g., `a1` to `z1`, followed by `a2` to `z2`).
+#'       sequential numeric indices (e.g., `a1` to `z1`, followed by `a2` to `z2`).
 #'     - Finally, the name of a user-defined object that is available in the
 #'       environment can be used. Note that the object's name is not allowed to
 #'       be one of the pre-defined tokens, `"col"`, `"n"` and `"letter"`.
@@ -266,7 +266,7 @@ data_rename <- function(data,
       # if so, iterate all tokens
       for (token in matches) {
         # evaluate token-object from the environment
-         values <- .dynEval(
+        values <- .dynEval(
           str2lang(gsub("\\{(.*)\\}", "\\1", token)),
           ifnotfound = insight::format_error(paste0(
             "The object `", token, "` was not found. Please check if it really exists."

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -222,7 +222,7 @@ data_rename <- function(data,
   out <- rep_len("", length(pattern))
 
   # for alphabetical letters, we prepare a string if we have more than
-  # 26 columns # to rename
+  # 26 columns to rename
   if (length(out) > 26) {
     long_letters <- paste0(
       rep.int(letters[1:26], times = ceiling(length(out) / 26)),

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -266,13 +266,11 @@ data_rename <- function(data,
       # if so, iterate all tokens
       for (token in matches) {
         # evaluate token-object from the environment
-         values <- tryCatch(
-          .dynEval(str2lang(gsub("\\{(.*)\\}", "\\1", token))),
-          error = function(e) {
-            insight::format_error(paste0(
-              "The object `", token, "` was not found. Please check if it really exists."
-            ))
-          }
+         values <- .dynEval(
+          str2lang(gsub("\\{(.*)\\}", "\\1", token)),
+          ifnotfound = insight::format_error(paste0(
+            "The object `", token, "` was not found. Please check if it really exists."
+          ))
         )
         # check for correct length
         if (length(values) != length(pattern)) {

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -24,9 +24,10 @@
 #'     in `pattern`. `pattern` and `replacement` must be of the same length.
 #'   - `NULL`, in which case columns are numbered in sequential order.
 #'   - A string (i.e. character vector of length 1) with a "glue" styled pattern.
-#'     Currently supported tokens are `{col}` and `{n}`. `{col}` will be replaced
-#'     by the column name, i.e. the corresponding value in `pattern`. `{n}` will
-#'     be replaced by the number of the variable that is replaced. For instance,
+#'     Currently supported tokens are `{col}` (or `{name}`) and `{n}`. `{col}`
+#'     will be replaced by the column name, i.e. the corresponding value in
+#'     `pattern`. `{n}` will be replaced by the number of the variable that is
+#'     replaced. For instance,
 #'     ```r
 #'     data_rename(
 #'       mtcars,
@@ -204,7 +205,7 @@ data_rename <- function(data,
 .glue_replacement <- function(pattern, replacement) {
   # this function replaces "glue" tokens into their related
   # real names/values. Currently, following tokens are accepted:
-  # - {col}: replacement is the name of the column (inidcated in "pattern")
+  # - {col}/{name}: replacement is the name of the column (indicated in "pattern")
   # - {n}: replacement is the number of the variable out of n, that should be renamed
   out <- rep_len("", length(pattern))
   for (i in seq_along(out)) {
@@ -214,6 +215,12 @@ data_rename <- function(data,
     # replace first accepted token
     out[i] <- gsub(
       "(.*)(\\{col\\})(.*)",
+      replacement = paste0("\\1", column_name, "\\3"),
+      x = out[i]
+    )
+    # alias of {col} is {name}
+    out[i] <- gsub(
+      "(.*)(\\{name\\})(.*)",
       replacement = paste0("\\1", column_name, "\\3"),
       x = out[i]
     )

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -20,9 +20,9 @@
 #'     vector using `<new name> = "<old name>"` and argument `replacement` will
 #'     be ignored then).
 #' @param replacement Character vector. Can be one of the following:
-#'   - A character vector that indicates the new name of the columns selected in
-#'     `pattern`. `pattern` and `replacement` must be of the same length.
-#'   - `NULL`, in which case column are numbered in sequential order.
+#'   - A character vector that indicates the new names of the columns selected
+#'     in `pattern`. `pattern` and `replacement` must be of the same length.
+#'   - `NULL`, in which case columns are numbered in sequential order.
 #'   - A string (i.e. character vector of length 1) with a "curl" styled pattern.
 #'     Currently supported tokens are `{col}` and `{n}`. `{col}` will be replaced
 #'     by the column name, i.e. the corresponding value in `pattern`. `{n}` will
@@ -34,7 +34,7 @@
 #'       replacement = "new_name_from_{col}"
 #'     )
 #'     ```
-#'     would returns new column names `new_name_from_am` and `new_name_from__vs`.
+#'     would returns new column names `new_name_from_am` and `new_name_from_vs`.
 #'     See 'Examples'.
 #'
 #' If `pattern` is a named vector, `replacement` is ignored.

--- a/R/data_rename.R
+++ b/R/data_rename.R
@@ -30,7 +30,7 @@
 #'     - `{n}` will be replaced by the number of the variable that is replaced.
 #'     - `{letter}` will be replaced by alphabetical letters in sequential order.
 #'     - Finally, the name of a user-defined object that is available in the
-#'       environment can be used. In this case,
+#'       environment can be used.
 #'
 #'     An example for the use of tokens is...
 #'     ```r
@@ -262,7 +262,7 @@ data_rename <- function(data,
         if (length(values) != length(pattern)) {
           insight::format_error(paste0(
             "The number of values provided in `", token, "` (", length(values),
-            " values) do not match the number of the columns to rename (",
+            " values) do not match the number of columns to rename (",
             length(pattern), " columns)."
           ))
         }

--- a/man/categorize.Rd
+++ b/man/categorize.Rd
@@ -243,12 +243,16 @@ categorize(mtcars$mpg, "equal_length", n_groups = 5, labels = "observed")
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_match.Rd
+++ b/man/data_match.Rd
@@ -128,12 +128,16 @@ data_filter(mtcars, fl)
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_merge.Rd
+++ b/man/data_merge.Rd
@@ -190,12 +190,16 @@ data_merge(list(x, y, z), join = "bind", by = "id", id = "source")
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_partition.Rd
+++ b/man/data_partition.Rd
@@ -68,12 +68,16 @@ lapply(out, function(i) table(i$Species))
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_relocate.Rd
+++ b/man/data_relocate.Rd
@@ -134,12 +134,16 @@ head(data_remove(iris, starts_with("Sepal")))
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -116,10 +116,17 @@ functions (see 'Details'), this argument may be used as workaround.}
 in \code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
 \item \code{NULL}, in which case columns are numbered in sequential order.
 \item A string (i.e. character vector of length 1) with a "glue" styled pattern.
-Currently supported tokens are \code{{col}} (or \code{{name}}) and \code{{n}}. \code{{col}}
-will be replaced by the column name, i.e. the corresponding value in
-\code{pattern}. \code{{n}} will be replaced by the number of the variable that is
-replaced. For instance,
+Currently supported tokens are:
+\itemize{
+\item \code{{col}} (or \code{{name}}), which will be replaced by the column name, i.e.
+the corresponding value in \code{pattern}.
+\item \code{{n}} will be replaced by the number of the variable that is replaced.
+\item \code{{letter}} will be replaced by alphabetical letters in sequential order.
+\item Finally, the name of a user-defined object that is available in the
+environment can be used. In this case,
+}
+
+An example for the use of tokens is...
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{data_rename(
   mtcars,
@@ -128,8 +135,8 @@ replaced. For instance,
 )
 }\if{html}{\out{</div>}}
 
-would returns new column names \code{new_name_from_am} and \code{new_name_from_vs}.
-See 'Examples'.
+... which would return new column names \code{new_name_from_am} and
+\code{new_name_from_vs}. See 'Examples'.
 }
 
 If \code{pattern} is a named vector, \code{replacement} is ignored.}
@@ -174,6 +181,11 @@ head(data_rename(iris, replacement = paste0("Var", 1:5)))
 # Use glue-styled patterns
 head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
 head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
+head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "new_{letter}"))
+
+# User-defined glue-styled patterns from objects in environment
+x <- c("hi", "there", "!")
+head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "col_{x}"))
 }
 \seealso{
 \itemize{

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -116,9 +116,10 @@ functions (see 'Details'), this argument may be used as workaround.}
 in \code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
 \item \code{NULL}, in which case columns are numbered in sequential order.
 \item A string (i.e. character vector of length 1) with a "glue" styled pattern.
-Currently supported tokens are \code{{col}} and \code{{n}}. \code{{col}} will be replaced
-by the column name, i.e. the corresponding value in \code{pattern}. \code{{n}} will
-be replaced by the number of the variable that is replaced. For instance,
+Currently supported tokens are \code{{col}} (or \code{{name}}) and \code{{n}}. \code{{col}}
+will be replaced by the column name, i.e. the corresponding value in
+\code{pattern}. \code{{n}} will be replaced by the number of the variable that is
+replaced. For instance,
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{data_rename(
   mtcars,

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -115,7 +115,7 @@ functions (see 'Details'), this argument may be used as workaround.}
 \item A character vector that indicates the new names of the columns selected
 in \code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
 \item \code{NULL}, in which case columns are numbered in sequential order.
-\item A string (i.e. character vector of length 1) with a "curl" styled pattern.
+\item A string (i.e. character vector of length 1) with a "glue" styled pattern.
 Currently supported tokens are \code{{col}} and \code{{n}}. \code{{col}} will be replaced
 by the column name, i.e. the corresponding value in \code{pattern}. \code{{n}} will
 be replaced by the number of the variable that is replaced. For instance,
@@ -170,7 +170,7 @@ head(data_rename(iris, NULL))
 # Change all
 head(data_rename(iris, replacement = paste0("Var", 1:5)))
 
-# Use curl-styled patterns
+# Use glue-styled patterns
 head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
 head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
 }

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -123,7 +123,7 @@ the corresponding value in \code{pattern}.
 \item \code{{n}} will be replaced by the number of the variable that is replaced.
 \item \code{{letter}} will be replaced by alphabetical letters in sequential order.
 \item Finally, the name of a user-defined object that is available in the
-environment can be used. In this case,
+environment can be used.
 }
 
 An example for the use of tokens is...

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -176,12 +176,16 @@ head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -118,12 +118,15 @@ in \code{pattern}. \code{pattern} and \code{replacement} must be of the same len
 \item A string (i.e. character vector of length 1) with a "glue" styled pattern.
 Currently supported tokens are:
 \itemize{
-\item \code{{col}} (or \code{{name}}), which will be replaced by the column name, i.e.
-the corresponding value in \code{pattern}.
+\item \code{{col}} which will be replaced by the column name, i.e. the
+corresponding value in \code{pattern}.
 \item \code{{n}} will be replaced by the number of the variable that is replaced.
 \item \code{{letter}} will be replaced by alphabetical letters in sequential order.
+If more than 26 letters are required, letters are repeated, but have
+seqential numeric indices (e.g., \code{a1} to \code{z1}, followed by \code{a2} to \code{z2}).
 \item Finally, the name of a user-defined object that is available in the
-environment can be used.
+environment can be used. Note that the object's name is not allowed to
+be one of the pre-defined tokens, \code{"col"}, \code{"n"} and \code{"letter"}.
 }
 
 An example for the use of tokens is...

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -43,14 +43,17 @@ data_rename_rows(data, rows = NULL)
 \arguments{
 \item{data}{A data frame, or an object that can be coerced to a data frame.}
 
-\item{pattern}{Character vector. For \code{data_rename()}, indicates columns that
-should be selected for renaming. Can be \code{NULL} (in which case all columns
-are selected). For \code{data_addprefix()} or \code{data_addsuffix()}, a character
-string, which will be added as prefix or suffix to the column names. For
-\code{data_rename()}, \code{pattern} can also be a named vector. In this case, names
-are used as values for the \code{replacement} argument (i.e. \code{pattern} can be a
-character vector using \verb{<new name> = "<old name>"} and argument \code{replacement}
-will be ignored then).}
+\item{pattern}{Character vector.
+\itemize{
+\item For \code{data_addprefix()} or \code{data_addsuffix()}, a character string, which
+will be added as prefix or suffix to the column names.
+\item For \code{data_rename()}, indicates columns that should be selected for
+renaming. Can be \code{NULL} (in which case all columns are selected).
+\code{pattern} can also be a named vector. In this case, names are used as
+values for the \code{replacement} argument (i.e. \code{pattern} can be a character
+vector using \verb{<new name> = "<old name>"} and argument \code{replacement} will
+be ignored then).
+}}
 
 \item{select}{Variables that will be included when performing the required
 tasks. Can be either
@@ -107,10 +110,28 @@ functions (see 'Details'), this argument may be used as workaround.}
 
 \item{...}{Other arguments passed to or from other functions.}
 
-\item{replacement}{Character vector. Indicates the new name of the columns
-selected in \code{pattern}. Can be \code{NULL} (in which case column are numbered
-in sequential order). If not \code{NULL}, \code{pattern} and \code{replacement} must be
-of the same length. If \code{pattern} is a named vector, \code{replacement} is ignored.}
+\item{replacement}{Character vector. Can be one of the following:
+\itemize{
+\item A character vector that indicates the new name of the columns selected in
+\code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
+\item \code{NULL}, in which case column are numbered in sequential order.
+\item A string (i.e. character vector of length 1) with a "curl" styled pattern.
+Currently supported tokens are \code{{col}} and \code{{n}}. \code{{col}} will be replaced
+by the column name, i.e. the corresponding value in \code{pattern}. \code{{n}} will
+be replaced by the number of the variable that is replaced. For instance,
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{data_rename(
+  mtcars,
+  pattern = c("am", "vs"),
+  replacement = "new_name_from_\{col\}"
+)
+}\if{html}{\out{</div>}}
+
+would returns new column names \code{new_name_from_am} and \code{new_name_from__vs}.
+See 'Examples'.
+}
+
+If \code{pattern} is a named vector, \code{replacement} is ignored.}
 
 \item{safe}{Do not throw error if for instance the variable to be
 renamed/removed doesn't exist.}
@@ -148,6 +169,10 @@ head(data_rename(iris, NULL))
 
 # Change all
 head(data_rename(iris, replacement = paste0("Var", 1:5)))
+
+# Use curl-styled patterns
+head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
+head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
 }
 \seealso{
 \itemize{

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -112,9 +112,9 @@ functions (see 'Details'), this argument may be used as workaround.}
 
 \item{replacement}{Character vector. Can be one of the following:
 \itemize{
-\item A character vector that indicates the new name of the columns selected in
-\code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
-\item \code{NULL}, in which case column are numbered in sequential order.
+\item A character vector that indicates the new names of the columns selected
+in \code{pattern}. \code{pattern} and \code{replacement} must be of the same length.
+\item \code{NULL}, in which case columns are numbered in sequential order.
 \item A string (i.e. character vector of length 1) with a "curl" styled pattern.
 Currently supported tokens are \code{{col}} and \code{{n}}. \code{{col}} will be replaced
 by the column name, i.e. the corresponding value in \code{pattern}. \code{{n}} will
@@ -127,7 +127,7 @@ be replaced by the number of the variable that is replaced. For instance,
 )
 }\if{html}{\out{</div>}}
 
-would returns new column names \code{new_name_from_am} and \code{new_name_from__vs}.
+would returns new column names \code{new_name_from_am} and \code{new_name_from_vs}.
 See 'Examples'.
 }
 

--- a/man/data_rename.Rd
+++ b/man/data_rename.Rd
@@ -123,7 +123,7 @@ corresponding value in \code{pattern}.
 \item \code{{n}} will be replaced by the number of the variable that is replaced.
 \item \code{{letter}} will be replaced by alphabetical letters in sequential order.
 If more than 26 letters are required, letters are repeated, but have
-seqential numeric indices (e.g., \code{a1} to \code{z1}, followed by \code{a2} to \code{z2}).
+sequential numeric indices (e.g., \code{a1} to \code{z1}, followed by \code{a2} to \code{z2}).
 \item Finally, the name of a user-defined object that is available in the
 environment can be used. Note that the object's name is not allowed to
 be one of the pre-defined tokens, \code{"col"}, \code{"n"} and \code{"letter"}.

--- a/man/data_rotate.Rd
+++ b/man/data_rotate.Rd
@@ -52,12 +52,16 @@ data_rotate(x, colnames = "c")
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_to_long.Rd
+++ b/man/data_to_long.Rd
@@ -222,12 +222,16 @@ head(even_longer_data)
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -208,12 +208,16 @@ data_to_wide(
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/extract_column_names.Rd
+++ b/man/extract_column_names.Rd
@@ -175,12 +175,16 @@ head(data_select(mtcars, c(`Miles per Gallon` = "mpg", Cylinders = "cyl")))
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/recode_values.Rd
+++ b/man/recode_values.Rd
@@ -278,12 +278,16 @@ options(data_recode_pattern = NULL)
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/slide.Rd
+++ b/man/slide.Rd
@@ -123,12 +123,16 @@ sapply(mtcars, min)
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/man/text_format.Rd
+++ b/man/text_format.Rd
@@ -50,14 +50,17 @@ text elements will not be enclosed.}
 
 \item{n}{The number of characters to find.}
 
-\item{pattern}{Character vector. For \code{data_rename()}, indicates columns that
-should be selected for renaming. Can be \code{NULL} (in which case all columns
-are selected). For \code{data_addprefix()} or \code{data_addsuffix()}, a character
-string, which will be added as prefix or suffix to the column names. For
-\code{data_rename()}, \code{pattern} can also be a named vector. In this case, names
-are used as values for the \code{replacement} argument (i.e. \code{pattern} can be a
-character vector using \verb{<new name> = "<old name>"} and argument \code{replacement}
-will be ignored then).}
+\item{pattern}{Character vector.
+\itemize{
+\item For \code{data_addprefix()} or \code{data_addsuffix()}, a character string, which
+will be added as prefix or suffix to the column names.
+\item For \code{data_rename()}, indicates columns that should be selected for
+renaming. Can be \code{NULL} (in which case all columns are selected).
+\code{pattern} can also be a named vector. In this case, names are used as
+values for the \code{replacement} argument (i.e. \code{pattern} can be a character
+vector using \verb{<new name> = "<old name>"} and argument \code{replacement} will
+be ignored then).
+}}
 }
 \value{
 A character string.

--- a/man/winsorize.Rd
+++ b/man/winsorize.Rd
@@ -82,12 +82,16 @@ winsorize(iris, threshold = 0.2)
 }
 \seealso{
 \itemize{
-\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}}, \code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
-\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}}, \code{\link[=data_remove]{data_remove()}}
-\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}}, \code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
+\item Functions to rename stuff: \code{\link[=data_rename]{data_rename()}}, \code{\link[=data_rename_rows]{data_rename_rows()}},
+\code{\link[=data_addprefix]{data_addprefix()}}, \code{\link[=data_addsuffix]{data_addsuffix()}}
+\item Functions to reorder or remove columns: \code{\link[=data_reorder]{data_reorder()}}, \code{\link[=data_relocate]{data_relocate()}},
+\code{\link[=data_remove]{data_remove()}}
+\item Functions to reshape, pivot or rotate data frames: \code{\link[=data_to_long]{data_to_long()}},
+\code{\link[=data_to_wide]{data_to_wide()}}, \code{\link[=data_rotate]{data_rotate()}}
 \item Functions to recode data: \code{\link[=rescale]{rescale()}}, \code{\link[=reverse]{reverse()}}, \code{\link[=categorize]{categorize()}},
 \code{\link[=recode_values]{recode_values()}}, \code{\link[=slide]{slide()}}
-\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}}, \code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
+\item Functions to standardize, normalize, rank-transform: \code{\link[=center]{center()}}, \code{\link[=standardize]{standardize()}},
+\code{\link[=normalize]{normalize()}}, \code{\link[=ranktransform]{ranktransform()}}, \code{\link[=winsorize]{winsorize()}}
 \item Split and merge data frames: \code{\link[=data_partition]{data_partition()}}, \code{\link[=data_merge]{data_merge()}}
 \item Functions to find or select columns: \code{\link[=data_select]{data_select()}}, \code{\link[=extract_column_names]{extract_column_names()}}
 \item Functions to filter rows: \code{\link[=data_match]{data_match()}}, \code{\link[=data_filter]{data_filter()}}

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -140,3 +140,14 @@ test_that("data_rename preserves attributes", {
 
   expect_named(a1, names(a2))
 })
+
+
+# curl-styled pattern --------------------------
+
+test_that("data_rename curl-style", {
+  data(mtcars)
+  out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}")
+  expect_named(out, c("formerly_mpg", "formerly_cyl", "formerly_disp"))
+  out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}")
+  expect_named(out, c("mpg_is_column_1", "cyl_is_column_2", "disp_is_column_3"))
+})

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -154,6 +154,35 @@ test_that("data_rename glue-style", {
   expect_named(out, c("new_a", "new_b", "new_c"))
 })
 
+test_that("data_rename enough letters", {
+  data(efc, package = "datawizard")
+  data(mtcars)
+  data(iris)
+  data(ChickWeight)
+  data(ToothGrowth)
+  data(USArrests)
+  data(airquality)
+  x <- cbind(
+    mtcars[1:5, ], iris[1:5, ], efc[1:5, ], ChickWeight[1:5, ], ToothGrowth[1:5, ],
+    USArrests[1:5, ], airquality[1:5, ]
+  )
+  expect_names(
+    data_rename(x, replacement = "long_letter_{letter}"),
+    c(
+      "long_letter_a1", "long_letter_b1", "long_letter_c1", "long_letter_d1",
+      "long_letter_e1", "long_letter_f1", "long_letter_g1", "long_letter_h1",
+      "long_letter_i1", "long_letter_j1", "long_letter_k1", "long_letter_l1",
+      "long_letter_m1", "long_letter_n1", "long_letter_o1", "long_letter_p1",
+      "long_letter_q1", "long_letter_r1", "long_letter_s1", "long_letter_t1",
+      "long_letter_u1", "long_letter_v1", "long_letter_w1", "long_letter_x1",
+      "long_letter_y1", "long_letter_z1", "long_letter_a2", "long_letter_b2",
+      "long_letter_c2", "long_letter_d2", "long_letter_e2", "long_letter_f2",
+      "long_letter_g2", "long_letter_h2", "long_letter_i2", "long_letter_j2",
+      "long_letter_k2", "long_letter_l2"
+    )
+  )
+})
+
 skip_if_not_installed("withr")
 withr::with_environment(
   new.env(),
@@ -165,6 +194,35 @@ withr::with_environment(
     expect_error(
       data_rename(mtcars[1:3], c("mpg", "disp"), "col_{x}"),
       regex = "The number of values"
+    )
+  })
+)
+
+withr::with_environment(
+  new.env(),
+  test_that("data_rename glue-style, object not in environment", {
+    data(mtcars)
+    expect_error(
+      data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "col_{x}"),
+      regex = "The object"
+    )
+  })
+)
+
+withr::with_environment(
+  new.env(),
+  test_that("data_rename glue-style, function in environment", {
+    data(mtcars)
+    my_fun <- function(cols_to_rename) {
+      data_rename(head(mtcars)[, 1:6], cols_to_rename, "new_{col}")
+    }
+    expect_named(
+      my_fun(c("mpg", "drat")),
+      c("new_mpg", "cyl", "disp", "hp", "new_drat", "wt")
+    )
+    expect_named(
+      my_fun("mpg"),
+      c("new_mpg", "cyl", "disp", "hp", "drat", "wt")
     )
   })
 )

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -166,7 +166,7 @@ test_that("data_rename enough letters", {
     mtcars[1:5, ], iris[1:5, ], efc[1:5, ], ChickWeight[1:5, ], ToothGrowth[1:5, ],
     USArrests[1:5, ], airquality[1:5, ]
   )
-  expect_names(
+  expect_named(
     data_rename(x, replacement = "long_letter_{letter}"),
     c(
       "long_letter_a1", "long_letter_b1", "long_letter_c1", "long_letter_d1",

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -150,4 +150,21 @@ test_that("data_rename glue-style", {
   expect_named(out, c("formerly_mpg", "formerly_cyl", "formerly_disp"))
   out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}")
   expect_named(out, c("mpg_is_column_1", "cyl_is_column_2", "disp_is_column_3"))
+  out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "new_{letter}")
+  expect_named(out, c("new_a", "new_b", "new_c"))
 })
+
+skip_if_not_installed("withr")
+withr::with_environment(
+  new.env(),
+  test_that("data_rename glue-style, environment", {
+    data(mtcars)
+    x <- c("hi", "there", "!")
+    out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "col_{x}")
+    expect_named(out, c("col_hi", "col_there", "col_!"))
+    expect_error(
+      data_rename(mtcars[1:3], c("mpg", "disp"), "col_{x}"),
+      regex = "The number of values"
+    )
+  })
+)

--- a/tests/testthat/test-data_rename.R
+++ b/tests/testthat/test-data_rename.R
@@ -142,9 +142,9 @@ test_that("data_rename preserves attributes", {
 })
 
 
-# curl-styled pattern --------------------------
+# glue-styled pattern --------------------------
 
-test_that("data_rename curl-style", {
+test_that("data_rename glue-style", {
   data(mtcars)
   out <- data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}")
   expect_named(out, c("formerly_mpg", "formerly_cyl", "formerly_disp"))


### PR DESCRIPTION
``` r
library(datawizard)
head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "formerly_{col}"))
#>                   formerly_mpg formerly_cyl formerly_disp
#> Mazda RX4                 21.0            6           160
#> Mazda RX4 Wag             21.0            6           160
#> Datsun 710                22.8            4           108
#> Hornet 4 Drive            21.4            6           258
#> Hornet Sportabout         18.7            8           360
#> Valiant                   18.1            6           225
head(data_rename(mtcars[1:3], c("mpg", "cyl", "disp"), "{col}_is_column_{n}"))
#>                   mpg_is_column_1 cyl_is_column_2 disp_is_column_3
#> Mazda RX4                    21.0               6              160
#> Mazda RX4 Wag                21.0               6              160
#> Datsun 710                   22.8               4              108
#> Hornet 4 Drive               21.4               6              258
#> Hornet Sportabout            18.7               8              360
#> Valiant                      18.1               6              225
```

<sup>Created on 2024-11-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
