### PR TITLE
Give informative error in `data_codebook()` when `select` matched no variables.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.2
+Version: 1.0.2.3
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.1
+Version: 1.0.2.2
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # datawizard (devel)
 
+CHANGES
+
+* `data_codebook()` gives an informative warning when no column names matched
+  the selection pattern.
+
 BUG FIXES
 
 * Fixed bug in `data_to_wide()`, where new column names in `names_from` were

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 CHANGES
 
 * `data_codebook()` gives an informative warning when no column names matched
-  the selection pattern.
+  the selection pattern (#601).
 
 BUG FIXES
 

--- a/R/data_codebook.R
+++ b/R/data_codebook.R
@@ -87,6 +87,14 @@ data_codebook <- function(data,
     select <- select[-empty]
   }
 
+  # check if any columns left, or found
+  if (!length(select) || is.null(select)) {
+    if (isTRUE(verbose)) {
+      insight::format_warning("No column names that matched the required search pattern were found.")
+    }
+    return(NULL)
+  }
+
   # needed for % NA
   rows <- nrow(data)
   max_values <- max_values + 1

--- a/tests/testthat/test-data_codebook.R
+++ b/tests/testthat/test-data_codebook.R
@@ -207,3 +207,12 @@ test_that("data_codebook, negative label values #334", {
   )
   expect_snapshot(data_codebook(data.frame(x1, x2)))
 })
+
+
+test_that("data_codebook, informative warning if no match", {
+  data(iris)
+  expect_warning(
+    data_codebook(iris, select = starts_with("abc")),
+    regex = "No column names that matched"
+  )
+})


### PR DESCRIPTION
Was:

``` r
data(iris)
datawizard::data_codebook(iris, select = starts_with("abc"))
#> Error in names(out) <- replace(names(out), names(out) == pattern[i], replacement[i]): attempt to set an attribute on NULL
```

Is:

``` r
data(iris)
datawizard::data_codebook(iris, select = starts_with("abc"))
#> Warning: No column names that matched the required search pattern were found.
#> NULL
```
