### PR TITLE
Raise an error when `data_to_long()` uses unknown variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.3
+Version: 1.0.2.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ CHANGES
 * `data_codebook()` gives an informative warning when no column names matched
   the selection pattern (#601).
 
+* `data_to_long()` now errors when columns selected to reshape do not exist in
+  the data, to avoid nonsensical results that could be missed (#602).
+
 BUG FIXES
 
 * Fixed bug in `data_to_wide()`, where new column names in `names_from` were

--- a/R/data_codebook.R
+++ b/R/data_codebook.R
@@ -310,7 +310,7 @@ data_codebook <- function(data,
 # helper -----------------------
 
 
-#' @keyword internal
+#' @keywords internal
 .extract_variable_labels <- function(x, variable_label_width = NULL) {
   varlab <- attr(x, "label", exact = TRUE)
   if (!is.null(varlab) && length(varlab)) {
@@ -330,7 +330,7 @@ data_codebook <- function(data,
 }
 
 
-#' @keyword internal
+#' @keywords internal
 .finalize_result <- function(out) {
   # rename
   pattern <- c("variable_label", "values", "value_labels", "frq", "proportions")

--- a/R/data_to_long.R
+++ b/R/data_to_long.R
@@ -170,11 +170,6 @@ data_to_long <- function(data,
   }
   # nolint end
 
-  # nothing to select?
-  if (length(cols) == 0L) {
-    insight::format_error("No columns found for reshaping data.")
-  }
-
   if (length(names_to) > 1L && is.null(names_sep) && is.null(names_pattern)) {
     insight::format_error(
       "If you supply multiple names in `names_to`, you must also supply one of `names_sep` or `names_pattern`."

--- a/R/data_to_long.R
+++ b/R/data_to_long.R
@@ -138,6 +138,7 @@ data_to_long <- function(data,
                          rows_to = NULL,
                          ignore_case = FALSE,
                          regex = FALSE,
+                         verbose = TRUE,
                          ...,
                          cols) { # nolint
   original_data <- data
@@ -152,23 +153,21 @@ data_to_long <- function(data,
       exclude = NULL,
       ignore_case = ignore_case,
       regex = regex,
-      verbose = FALSE
+      verbose = verbose
+    )
+  } else if (!missing(select) || !is.null(select)) {
+    cols <- .select_nse(
+      select,
+      data,
+      exclude = NULL,
+      ignore_case = ignore_case,
+      regex = regex,
+      verbose = verbose
     )
   } else {
-    if (!missing(select) || !is.null(select)) {
-      cols <- .select_nse(
-        select,
-        data,
-        exclude = NULL,
-        ignore_case = ignore_case,
-        regex = regex,
-        verbose = FALSE
-      )
-    } else {
-      insight::format_error(
-        "You need to specify columns to pivot, either with `select` or `cols`."
-      )
-    }
+    insight::format_error(
+      "You need to specify columns to pivot, either with `select` or `cols`."
+    )
   }
   # nolint end
 

--- a/R/data_to_long.R
+++ b/R/data_to_long.R
@@ -138,7 +138,6 @@ data_to_long <- function(data,
                          rows_to = NULL,
                          ignore_case = FALSE,
                          regex = FALSE,
-                         verbose = TRUE,
                          ...,
                          cols) { # nolint
   original_data <- data
@@ -153,7 +152,7 @@ data_to_long <- function(data,
       exclude = NULL,
       ignore_case = ignore_case,
       regex = regex,
-      verbose = verbose
+      ifnotfound = "error"
     )
   } else if (!missing(select) || !is.null(select)) {
     cols <- .select_nse(
@@ -162,7 +161,7 @@ data_to_long <- function(data,
       exclude = NULL,
       ignore_case = ignore_case,
       regex = regex,
-      verbose = verbose
+      ifnotfound = "error"
     )
   } else {
     insight::format_error(

--- a/man/data_to_long.Rd
+++ b/man/data_to_long.Rd
@@ -17,7 +17,6 @@ data_to_long(
   rows_to = NULL,
   ignore_case = FALSE,
   regex = FALSE,
-  verbose = TRUE,
   ...,
   cols
 )
@@ -34,7 +33,6 @@ reshape_longer(
   rows_to = NULL,
   ignore_case = FALSE,
   regex = FALSE,
-  verbose = TRUE,
   ...,
   cols
 )
@@ -119,8 +117,6 @@ of length > 1. \code{regex = TRUE} is comparable to using one of the two
 select-helpers, \code{select = contains()} or \code{select = regex()}, however,
 since the select-helpers may not work when called from inside other
 functions (see 'Details'), this argument may be used as workaround.}
-
-\item{verbose}{Toggle warnings.}
 
 \item{...}{Currently not used.}
 

--- a/man/data_to_long.Rd
+++ b/man/data_to_long.Rd
@@ -17,6 +17,7 @@ data_to_long(
   rows_to = NULL,
   ignore_case = FALSE,
   regex = FALSE,
+  verbose = TRUE,
   ...,
   cols
 )
@@ -33,6 +34,7 @@ reshape_longer(
   rows_to = NULL,
   ignore_case = FALSE,
   regex = FALSE,
+  verbose = TRUE,
   ...,
   cols
 )
@@ -117,6 +119,8 @@ of length > 1. \code{regex = TRUE} is comparable to using one of the two
 select-helpers, \code{select = contains()} or \code{select = regex()}, however,
 since the select-helpers may not work when called from inside other
 functions (see 'Details'), this argument may be used as workaround.}
+
+\item{verbose}{Toggle warnings.}
 
 \item{...}{Currently not used.}
 

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -505,7 +505,7 @@ test_that("tell user about typos", {
     names_to = "time",
     values_to = "count"
   ))
-  expect_warning(expect_warning(
+  expect_error(
     data_to_long(
       mtcars,
       select = c("mpg", "ho", "dist"),
@@ -513,12 +513,5 @@ test_that("tell user about typos", {
       values_to = "count"
     ),
     regex = "Following"
-  ))
-  expect_silent(data_to_long(
-    mtcars,
-    select = c("mpg", "ho", "dist"),
-    names_to = "time",
-    values_to = "count",
-    verbose = FALSE
-  ))
+  )
 })

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -247,9 +247,12 @@ test_that("data_to_long: can't use sep or pattern if only one names_to", {
 })
 
 test_that("data_to_long: error if no columns to reshape", {
+  # since #602, we no longer have the case that .select_nse() returns no
+  # columns, because we error before when no column found, instead of returning
+  # NULL or a vector of lenght zero.
   expect_error(
     data_to_long(wide_data, cols = "foo"),
-    "No columns found"
+    "Possibly misspelled"
   )
 })
 

--- a/tests/testthat/test-data_to_long.R
+++ b/tests/testthat/test-data_to_long.R
@@ -495,3 +495,30 @@ test_that("don't convert factors to integer", {
   )
   expect_snapshot(print(mtcars_long))
 })
+
+
+test_that("tell user about typos", {
+  data("mtcars")
+  expect_silent(data_to_long(
+    mtcars,
+    select = c("mpg", "hp", "disp"),
+    names_to = "time",
+    values_to = "count"
+  ))
+  expect_warning(expect_warning(
+    data_to_long(
+      mtcars,
+      select = c("mpg", "ho", "dist"),
+      names_to = "time",
+      values_to = "count"
+    ),
+    regex = "Following"
+  ))
+  expect_silent(data_to_long(
+    mtcars,
+    select = c("mpg", "ho", "dist"),
+    names_to = "time",
+    values_to = "count",
+    verbose = FALSE
+  ))
+})


### PR DESCRIPTION
Not sure if there's a reason why we set `verbose = FALSE` when we call `.select_nse()` inside `data_to_long()`, but today during teaching, I realized that the spell-checker is helpful in identifying typos. I suggest we add a `verbose` option.