### PR TITLE
`data_read()` no longer coerces Stan models into data frames.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.5
+Version: 1.0.2.7
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 BREAKING CHANGES
 
 * `data_read()` now also returns Bayesian models from packages *brms* and
-  *rstanarm* as original mpdel objects, and no longer coerces them into data
+  *rstanarm* as original model objects, and no longer coerces them into data
   frames.
 
 CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # datawizard (devel)
 
+BREAKING CHANGES
+
+* `data_read()` now also returns Bayesian models from packages *brms* and
+  *rstanarm* as original mpdel objects, and no longer coerces them into data
+  frames.
+
 CHANGES
 
 * `data_codebook()` gives an informative warning when no column names matched

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ BREAKING CHANGES
 
 * `data_read()` now also returns Bayesian models from packages *brms* and
   *rstanarm* as original model objects, and no longer coerces them into data
-  frames.
+  frames (#606).
 
 CHANGES
 

--- a/R/data_read.R
+++ b/R/data_read.R
@@ -295,10 +295,25 @@ data_read <- function(path,
   # set up arguments. for RDS, we set trust = TRUE, to avoid warnings
   rio_args <- list(file = path)
   # check if we have RDS, and if so, add trust = TRUE
-  if (file_type %in% c("rds", "rdata")) {
+  if (file_type %in% c("rds", "rdata", "rda")) {
     rio_args$trust <- TRUE
   }
   out <- do.call(rio::import, c(rio_args, list(...)))
+
+  # it is also possible to read in pre-compiled model objects with data_read()
+  # in this case, just return as is. We do this check before we check with
+  # "is.data.frame()", because some models (like brmsfit) have an `as.data.frame()`
+  # method, which coerces the model object into a data frame, which is likely to
+  # be not intentional
+  if (insight::is_model(out)) {
+    if (verbose) {
+      insight::format_alert(
+        paste0("Imported file is a regression model object of class \"", class(out)[1], "\"."),
+        "Returning file as is."
+      )
+    }
+    return(out)
+  }
 
   # for "unknown" data formats (like .RDS), which still can be imported via
   # "rio::import()", we must check whether we actually have a data frame or

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -56,6 +56,7 @@ Winsorizing
 al
 behaviour
 behaviours
+brms
 codebook
 codebooks
 codecov
@@ -108,6 +109,7 @@ rescaled
 rescaling
 rio
 rowid
+rstanarm
 sd
 stackexchange
 tailedness

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -447,7 +447,7 @@ test_that("data_read - RDS file, no data frame", {
       },
       regex = "no data frame"
     )
-    expect_s3_class(d, "list")
+    expect_true(is.list(d))
   })
 })
 
@@ -460,7 +460,7 @@ test_that("data_read - RDA file, model object", {
     httr::stop_for_status(request)
     writeBin(httr::content(request, type = "raw"), temp_file)
 
-    expect_warning(
+    expect_message(
       {
         d <- data_read(
           temp_file,
@@ -477,7 +477,7 @@ test_that("data_read - RDA file, model object", {
     httr::stop_for_status(request)
     writeBin(httr::content(request, type = "raw"), temp_file)
 
-    expect_warning(
+    expect_message(
       {
         d <- data_read(
           temp_file,

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -447,7 +447,7 @@ test_that("data_read - RDS file, no data frame", {
       },
       regex = "no data frame"
     )
-    expect_true(is.list(d))
+    expect_type(d, "list")
   })
 })
 

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -450,3 +450,25 @@ test_that("data_read - RDS file, no data frame", {
     expect_s3_class(d, "lm")
   })
 })
+
+
+test_that("data_read - RDA file, model object", {
+  skip_if_not_installed("withr")
+
+  withr::with_tempfile("temp_file", fileext = ".rda", code = {
+    request <- httr::GET("https://github.com/easystats/circus/raw/refs/heads/main/data/brms_1.rda")
+    httr::stop_for_status(request)
+    writeBin(httr::content(request, type = "raw"), temp_file)
+
+    expect_warning(
+      {
+        d <- data_read(
+          temp_file,
+          verbose = TRUE
+        )
+      },
+      regex = "Imported file is a regression"
+    )
+    expect_s3_class(d, "brmsfit")
+  })
+})

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -433,8 +433,8 @@ test_that("data_read, file not exists", {
 test_that("data_read - RDS file, no data frame", {
   skip_if_not_installed("withr")
 
-  withr::with_tempfile("temp_file", fileext = ".rds", code = {
-    request <- httr::GET("https://raw.github.com/easystats/circus/main/data/model_object.rds")
+  withr::with_tempfile("temp_file", fileext = ".rda", code = {
+    request <- httr::GET("https://raw.github.com/easystats/circus/main/data/list_for_testing.rda")
     httr::stop_for_status(request)
     writeBin(httr::content(request, type = "raw"), temp_file)
 
@@ -447,7 +447,7 @@ test_that("data_read - RDS file, no data frame", {
       },
       regex = "no data frame"
     )
-    expect_s3_class(d, "lm")
+    expect_s3_class(d, "list")
   })
 })
 
@@ -455,8 +455,25 @@ test_that("data_read - RDS file, no data frame", {
 test_that("data_read - RDA file, model object", {
   skip_if_not_installed("withr")
 
+  withr::with_tempfile("temp_file", fileext = ".rds", code = {
+    request <- httr::GET("https://raw.github.com/easystats/circus/main/data/model_object.rds")
+    httr::stop_for_status(request)
+    writeBin(httr::content(request, type = "raw"), temp_file)
+
+    expect_warning(
+      {
+        d <- data_read(
+          temp_file,
+          verbose = TRUE
+        )
+      },
+      regex = "Imported file is a regression"
+    )
+    expect_s3_class(d, "lm")
+  })
+
   withr::with_tempfile("temp_file", fileext = ".rda", code = {
-    request <- httr::GET("https://github.com/easystats/circus/raw/refs/heads/main/data/brms_1.rda")
+    request <- httr::GET("https://raw.github.com/easystats/circus/main/data/brms_1.rda")
     httr::stop_for_status(request)
     writeBin(httr::content(request, type = "raw"), temp_file)
 


### PR DESCRIPTION
@DominiqueMakowski This was the issue I was facing when downloading chocominimodel with `data_read()`. It tries to coerce data into a data frame, if possible. And it is possible with stan models. Thus, this PR implements a better check, so you can also download models from internet using `data_read()`.