### PR TITLE
Drop empty group combinations in `describe_distribution()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.7
+Version: 1.0.2.8
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@ BUG FIXES
 * Fixed bug in `data_to_wide()`, where new column names in `names_from` were
   ignored when that column only contained one unique value.
 
+* Fixed bug in `describe_distribution()` when some group combinations didn't appear in the data (#609).
+
 # datawizard 1.0.2
 
 BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,8 @@ BUG FIXES
 * Fixed bug in `data_to_wide()`, where new column names in `names_from` were
   ignored when that column only contained one unique value.
 
-* Fixed bug in `describe_distribution()` when some group combinations didn't appear in the data (#609).
+* Fixed bug in `describe_distribution()` when some group combinations 
+  didn't appear in the data (#609).
 
 # datawizard 1.0.2
 

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -495,6 +495,7 @@ describe_distribution.grouped_df <- function(x,
   group_vars <- setdiff(colnames(attributes(x)$groups), ".rows")
   group_data <- expand.grid(lapply(x[group_vars], function(i) unique(sort(i))))
   groups <- split(x, x[group_vars])
+  groups <- Filter(function(x) nrow(x) > 0, groups)
   select <- .select_nse(select,
     x,
     exclude,

--- a/tests/testthat/test-data_recode.R
+++ b/tests/testthat/test-data_recode.R
@@ -3,7 +3,6 @@
 options(data_recode_pattern = "old=new")
 
 
-
 # numeric -----------------------
 
 set.seed(123)

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -269,6 +269,7 @@ test_that("argument 'by' works", {
 })
 
 test_that("empty groups are discarded from the output, #608", {
+  skip_if_not_installed("bayestestR")
   dat <- data.frame(
     grp1 = factor("a", levels = c("a", "b")),
     grp2 = factor(c("A", "B")),

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -268,6 +268,18 @@ test_that("argument 'by' works", {
   )
 })
 
+test_that("empty groups are discarded from the output, #608", {
+  dat <- data.frame(
+    grp1 = factor("a", levels = c("a", "b")),
+    grp2 = factor(c("A", "B")),
+    value = 1:2
+  )
+  dat <- data_group(dat, c("grp1", "grp2"))
+  expect_no_error(
+    suppressWarnings(describe_distribution(dat, ci = 0.95))
+  )
+})
+
 # distribution_mode --------------------------
 test_that("distribution_mode works as expected", {
   skip_if_not_installed("bayestestR")


### PR DESCRIPTION
Fixes #608 