### PR TITLE
Rework formatted output of `describe_distribution()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.0.2.8
+Version: 1.0.2.9
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ BREAKING CHANGES
   *rstanarm* as original model objects, and no longer coerces them into data
   frames (#606).
 
+* The output format of `describe_distribution()` on grouped data has changed.
+  Before, it printed one table per group combination. Now, it prints a single
+  table with group columns at the start (#610).
+
 CHANGES
 
 * `data_codebook()` gives an informative warning when no column names matched

--- a/R/describe_distribution.R
+++ b/R/describe_distribution.R
@@ -519,12 +519,10 @@ describe_distribution.grouped_df <- function(x,
       ...
     )
 
-    d[[".group"]] <-
-      paste(sprintf(
-        "%s=%s",
-        group_vars,
-        vapply(group_data[i, ], as.character, FUN.VALUE = character(1L))
-      ), collapse = " | ")
+    for (grp in seq_along(group_vars)) {
+      d[[group_vars[grp]]] <- group_data[i, grp]
+    }
+    d <- data_relocate(d, group_vars, before = 1)
 
     d
   }))

--- a/R/format.R
+++ b/R/format.R
@@ -15,7 +15,14 @@ format.parameters_distribution <- function(x, digits = 2, format = NULL, ci_widt
   }
 
   if (all(c("CI_low", "CI_high") %in% names(x))) {
-    x$CI_low <- insight::format_ci(x$CI_low, x$CI_high, ci = NULL, digits = digits, width = ci_width, brackets = ci_brackets)
+    x$CI_low <- insight::format_ci(
+      x$CI_low, 
+      x$CI_high, 
+      ci = NULL, 
+      digits = digits, 
+      width = ci_width, 
+      brackets = ci_brackets
+    )
     x$CI_high <- NULL
     ci_lvl <- attributes(x)$ci
     centrality_ci <- attributes(x)$first_centrality

--- a/R/format.R
+++ b/R/format.R
@@ -43,23 +43,5 @@ format.parameters_distribution <- function(x, digits = 2, format = NULL, ci_widt
     colnames(x)[which(colnames(x) == "Trimmed_Mean")] <- trim_name
   }
 
-  if (".group" %in% colnames(x)) {
-    final_table <- list()
-    grps <- split(x, x[[".group"]])
-    for (i in names(grps)) {
-      grps[[i]][[".group"]] <- NULL
-      table_caption <- NULL
-      if (is.null(format) || format == "text") {
-        table_caption <- c(sprintf("# %s", i), "blue")
-      } else if (format == "markdown") {
-        table_caption <- sprintf("%s", i)
-      }
-      attr(grps[[i]], "table_caption") <- table_caption
-      final_table <- c(final_table, list(grps[[i]]))
-    }
-  } else {
-    final_table <- x
-  }
-
-  final_table
+  x
 }

--- a/tests/testthat/_snaps/describe_distribution.md
+++ b/tests/testthat/_snaps/describe_distribution.md
@@ -16,6 +16,58 @@
       -----------------------------------------------------------
            |    | [VC, OJ] |        0 |    -2.07 | 60 |         0
 
+# describe_distribution - grouped df
+
+    Code
+      out
+    Output
+      Species    |     Variable | Mean |   SD |  IQR |        Range | Skewness
+      ------------------------------------------------------------------------
+      setosa     | Petal.Length | 1.46 | 0.17 | 0.20 | [1.00, 1.90] |     0.11
+      setosa     |  Petal.Width | 0.25 | 0.11 | 0.10 | [0.10, 0.60] |     1.25
+      versicolor | Petal.Length | 4.26 | 0.47 | 0.60 | [3.00, 5.10] |    -0.61
+      versicolor |  Petal.Width | 1.33 | 0.20 | 0.30 | [1.00, 1.80] |    -0.03
+      virginica  | Petal.Length | 5.55 | 0.55 | 0.80 | [4.50, 6.90] |     0.55
+      virginica  |  Petal.Width | 2.03 | 0.27 | 0.50 | [1.40, 2.50] |    -0.13
+      
+      Species    | Kurtosis |  n | n_Missing
+      --------------------------------------
+      setosa     |     1.02 | 50 |         0
+      setosa     |     1.72 | 50 |         0
+      versicolor |     0.05 | 50 |         0
+      versicolor |    -0.41 | 50 |         0
+      virginica  |    -0.15 | 50 |         0
+      virginica  |    -0.60 | 50 |         0
+
+# describe_distribution - grouped df and multiple groups
+
+    Code
+      describe_distribution(x)
+    Output
+      grp1 | grp2 | Variable |  Mean |    SD |   IQR |          Range | Skewness
+      --------------------------------------------------------------------------
+      a    |    a |   values | 10.00 |  6.48 | 12.00 |  [1.00, 19.00] |     0.00
+      b    |    a |   values | 13.86 | 10.92 | 21.00 |  [1.00, 28.00] |     0.23
+      c    |    a |   values | 20.50 |  5.61 | 10.50 | [13.00, 28.00] |     0.00
+      a    |    b |   values | 11.00 |  6.48 | 12.00 |  [2.00, 20.00] |     0.00
+      b    |    b |   values | 15.50 | 11.81 | 22.50 |  [2.00, 29.00] |     0.00
+      c    |    b |   values | 20.00 |  6.48 | 12.00 | [11.00, 29.00] |     0.00
+      a    |    c |   values | 10.50 |  5.61 | 10.50 |  [3.00, 18.00] |     0.00
+      b    |    c |   values | 17.14 | 10.92 | 21.00 |  [3.00, 30.00] |    -0.23
+      c    |    c |   values | 21.00 |  6.48 | 12.00 | [12.00, 30.00] |     0.00
+      
+      grp1 | Kurtosis | n | n_Missing
+      -------------------------------
+      a    |    -1.20 | 7 |         0
+      b    |    -2.14 | 7 |         0
+      c    |    -1.20 | 6 |         0
+      a    |    -1.20 | 7 |         0
+      b    |    -2.76 | 6 |         0
+      c    |    -1.20 | 7 |         0
+      a    |    -1.20 | 6 |         0
+      b    |    -2.14 | 7 |         0
+      c    |    -1.20 | 7 |         0
+
 # describe_distribution formatting
 
     Code

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -36,7 +36,7 @@ testthat::set_state_inspector(function() {
 
   list(
     attached = search(),
-    # connections = nrow(showConnections()),
+    connections = nrow(showConnections()),
     cwd = getwd(),
     envvars = Sys.getenv(),
     libpaths = .libPaths(),

--- a/tests/testthat/helper-state.R
+++ b/tests/testthat/helper-state.R
@@ -36,7 +36,7 @@ testthat::set_state_inspector(function() {
 
   list(
     attached = search(),
-    connections = nrow(showConnections()),
+    # connections = nrow(showConnections()),
     cwd = getwd(),
     envvars = Sys.getenv(),
     libpaths = .libPaths(),

--- a/tests/testthat/test-describe_distribution.R
+++ b/tests/testthat/test-describe_distribution.R
@@ -229,17 +229,20 @@ test_that("describe_distribution - grouped df", {
   x <- data_group(iris, Species)
   out <- describe_distribution(x, select = starts_with("Petal"))
 
-  expect_identical(out$.group, c(
-    "Species=setosa", "Species=setosa",
-    "Species=versicolor", "Species=versicolor",
-    "Species=virginica", "Species=virginica"
-  ))
-  expect_identical(out$Variable, c(
-    "Petal.Length", "Petal.Width",
-    "Petal.Length", "Petal.Width",
-    "Petal.Length", "Petal.Width"
-  ))
+  expect_snapshot(out)
   expect_equal(out$Mean, c(1.462, 0.246, 4.26, 1.326, 5.552, 2.026), tolerance = 1e-3)
+})
+
+# Mostly to test printing
+test_that("describe_distribution - grouped df and multiple groups", {
+  skip_if_not_installed("bayestestR")
+  x <- data.frame(
+    grp1 = rep(letters[1:3], each = 20),
+    grp2 = rep(letters[1:3], 20),
+    values = 1:30
+  )
+  x <- data_group(x, c("grp1", "grp2"))
+  expect_snapshot(describe_distribution(x))
 })
 
 test_that("argument 'by' works", {


### PR DESCRIPTION
Fixes #599.

Here's what I get with a quarto HTML output (on two variables only):

```r
## One group
palmerpenguins::penguins |>
  group_by(species) |>
  describe_distribution(select = c("bill_length_mm", "bill_depth_mm")) |>
  insight::display()

## Two groups
palmerpenguins::penguins |>
  group_by(species, island) |>
  describe_distribution(select = c("bill_length_mm", "bill_depth_mm")) |>
  insight::display()
```

![image](https://github.com/user-attachments/assets/5610f008-372c-45ed-9e1e-8cb886190955)

@profandyfield @strengejacke @DominiqueMakowski is this what you'd like?