### PR TITLE
fixed crossed with more than 2 groupings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.2.0.1
+Version: 1.2.0.2
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 BUG FIXES
 
-* Fixed an issue when `demean()`ing nested structures (#635).
+* Fixed an issue when `demean()`ing nested structures with more than 2 grouping variables (#635).
+* Fixed an issue when `demean()`ing crossed structures with more than 2 grouping variables.
 
 # datawizard 1.2.0
 

--- a/R/demean.R
+++ b/R/demean.R
@@ -481,11 +481,13 @@ degroup <- function(x,
       names(out) <- paste0(select, "_", j)
       out
     })
+    group_means_list <- unlist(group_means_list, recursive = FALSE)
+
     # de-meaned variables for cross-classified design is simply subtracting
     # all group means from each individual value
-    person_means_list <- lapply(seq_along(select), function(i) {
-      sum_group_means <- do.call(`+`, lapply(group_means_list, function(j) j[[i]]))
-      dat[[select[i]]] - sum_group_means
+    person_means_list <- lapply(select, function(i) {
+      sum_group_means <- Reduce("+", group_means_list[paste0(i, "_", by)])
+      dat[[i]] - sum_group_means
     })
   }
 

--- a/tests/testthat/test-demean.R
+++ b/tests/testthat/test-demean.R
@@ -175,6 +175,30 @@ test_that("demean for cross-classified designs (by > 1)", {
     tolerance = 1e-4,
     ignore_attr = TRUE
   )
+
+
+  # More than 2 groupings
+  mu <- 100
+  ul <- setNames(c(-1, -3, 0, 4), nm = letters[1:4])
+  uL <- setNames(c(10, 30, 0, -40), nm = LETTERS[1:4])
+  um <- setNames(c(100, 150, -250), nm = month.abb[1:3])
+
+  dat <- expand.grid(l = letters[1:4], L = LETTERS[1:4], m = month.abb[1:3])
+
+  set.seed(111)
+  e <- rnorm(nrow(dat) - 1) |> round(2)
+  e <- append(e, -sum(e))
+
+  dat$y <- mu + ul[dat$l] + uL[dat$L] + um[dat$m] + e
+  dat$z <- mu + ul[dat$l] + uL[dat$L] + um[dat$m] + 10 * e
+
+  dat_dem <- datawizard::demean(dat, by = c("l", "L", "m"), select = c("y", "z"))
+
+  expect_equal(dat_dem$y_l_between, ave(dat$y, dat$l), ignore_attr = TRUE)
+  expect_equal(dat_dem$y_L_between, ave(dat$y, dat$L), ignore_attr = TRUE)
+  expect_equal(dat_dem$y_m_between, ave(dat$y, dat$m), ignore_attr = TRUE)
+  expect_equal(rowSums(dat_dem[grepl("^y_", colnames(dat_dem))]), dat$y)
+  expect_equal(rowSums(dat_dem[grepl("^z_", colnames(dat_dem))]), dat$z)
 })
 
 


### PR DESCRIPTION
This PR makes the crossed de-meaning more robust and fixes an error caused by having more than two crossed grouping variables.