### PR TITLE
Fix `data_to_wide()` on unbalanced panel with multiple variables in `values_from` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.2.0.2
+Version: 1.2.0.3
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,12 @@ BUG FIXES
 
 * Fixed an issue when `demean()`ing nested structures with more than 2 grouping
   variables (#635).
+
 * Fixed an issue when `demean()`ing crossed structures with more than 2 grouping
   variables (#638).
+
+* Fixed issue in `data_to_wide()` with multiple variables assigned in
+  `values_from` when missing values were present.
 
 # datawizard 1.2.0
 
@@ -78,7 +82,7 @@ CHANGES
 
 * `data_codebook()` gives an informative warning when no column names matched
   the selection pattern (#601).
-  
+
 * `data_to_long()` now errors when columns selected to reshape do not exist in
   the data, to avoid nonsensical results that could be missed (#602).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,8 @@ BUG FIXES
   variables (#638).
 
 * Fixed issue in `data_to_wide()` with multiple variables assigned in
-  `values_from` when IDs were not balanced (equally spread across observations).
+  `values_from` when IDs were not balanced (equally spread across observations)
+  (#644).
 
 # datawizard 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ BUG FIXES
   variables (#638).
 
 * Fixed issue in `data_to_wide()` with multiple variables assigned in
-  `values_from` when missing values were present.
+  `values_from` when IDs were not balanced (equally spread across observations).
 
 # datawizard 1.2.0
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -227,25 +227,6 @@ data_to_wide <- function(data,
   # create missing combinations
 
   if (not_all_cols_are_selected && incomplete_groups) {
-
-    # for multiple variables that should be reshaped into wide format, we
-    # need to rely on `stats::reshape()` - thus, we stop early here
-    if (!is.null(values_from) && length(values_from) > 1) {
-      return(.reshape_multiple_variables_to_wide(
-        x = data,
-        id_cols = id_cols,
-        names_from = names_from,
-        values_from = values_from,
-        names_sep = names_sep,
-        names_prefix = names_prefix,
-        names_glue = names_glue,
-        values_fill = values_fill,
-        custom_attr = custom_attr,
-        verbose = verbose,
-        ...
-      ))
-    }
-
     expanded <- expand.grid(unique(new_data[["temporary_id"]]), unique(new_data[[names_from]]))
     names(expanded) <- c("temporary_id", names_from)
     new_data <- data_merge(new_data, expanded,
@@ -264,7 +245,7 @@ data_to_wide <- function(data,
     # must be rearranged as "B" "B" "A" "A" and not "A" "A" "B" "B"
     lookup <- data.frame(
       temporary_id = unique(
-        new_data[!is.na(new_data[[values_from]]), "temporary_id"]
+        new_data[!is.na(new_data[values_from]), "temporary_id"]
       )
     )
     lookup$temporary_id_2 <- seq_len(nrow(lookup))
@@ -388,7 +369,16 @@ data_to_wide <- function(data,
 
 .unstack <- function(x, names_from, values_from, names_sep, names_prefix, names_glue = NULL) {
   # get values from names_from (future colnames)
-  x <- .modify_reshaped_colnames(x, names_from, names_sep, names_prefix, names_glue)
+
+  if (is.null(names_glue)) {
+    x$future_colnames <- do.call(paste, c(x[, names_from, drop = FALSE], sep = names_sep))
+  } else {
+    vars <- regmatches(names_glue, gregexpr("\\{\\K[^{}]+(?=\\})", names_glue, perl = TRUE))[[1]]
+    tmp_data <- x[, vars]
+    x$future_colnames <- .gluestick(names_glue, src = tmp_data)
+  }
+
+  x$future_colnames <- paste0(names_prefix, x$future_colnames)
 
   # expand the values for each variable in "values_from"
   res <- list()
@@ -424,52 +414,6 @@ data_to_wide <- function(data,
 }
 
 
-.modify_reshaped_colnames <- function(x, names_from, names_sep, names_prefix, names_glue) {
-  # get values from names_from (future colnames)
-  if (is.null(names_glue)) {
-    x$future_colnames <- do.call(paste, c(x[, names_from, drop = FALSE], sep = names_sep))
-  } else {
-    vars <- regmatches(names_glue, gregexpr("\\{\\K[^{}]+(?=\\})", names_glue, perl = TRUE))[[1]]
-    tmp_data <- x[, vars]
-    x$future_colnames <- .gluestick(names_glue, src = tmp_data)
-  }
-
-  x$future_colnames <- paste0(names_prefix, x$future_colnames)
-  x
-}
-
-
 #' @rdname data_to_wide
 #' @export
 reshape_wider <- data_to_wide
-
-
-.reshape_multiple_variables_to_wide <- function(
-  x,
-  id_cols = NULL,
-  values_from = "Value",
-  names_from = "Name",
-  names_sep = "_",
-  names_prefix = "",
-  names_glue = NULL,
-  values_fill = NULL,
-  custom_attr = NULL,
-  verbose = TRUE,
-  ...
-) {
-  # get values from names_from (future colnames)
-  x <- .modify_reshaped_colnames(x, names_from, names_sep, names_prefix, names_glue)
-  x[[names_from]] <- NULL
-
-  out <- stats::reshape(
-    data = x,
-    idvar = id_cols,
-    timevar = "future_colnames",
-    v.names = values_from,
-    direction = "wide"
-  )
-
-  # add back attributes
-  out <- .replace_attrs(out, custom_attr)
-  out
-}

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -308,10 +308,8 @@ data_to_wide <- function(data,
 
   if (length(values_from) > 1L) {
     unstacked$col_order <- unique(data[, names_from])
-    unstacked$col_order <- sort(
-      as.vector(
-        outer(values_from, unstacked$col_order, paste, sep = names_sep)
-      )
+    unstacked$col_order <- as.vector(
+      t(outer(values_from, unstacked$col_order, paste, sep = names_sep))
     )
   }
 

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -560,7 +560,7 @@ test_that("Preserve column name when names_from column only has one unique value
 })
 
 
-test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
+test_that("data_to_wide with multiple values_from and unbalanced panel", {
   skip_if_not_installed("tidyr")
   
   long_df <- tidyr::tibble(

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -562,7 +562,7 @@ test_that("Preserve column name when names_from column only has one unique value
 
 test_that("data_to_wide with multiple values_from and unbalanced panel", {
   skip_if_not_installed("tidyr")
-  
+
   long_df <- tidyr::tibble(
     subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
     time = rep(c(1, 2), 4),

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -558,3 +558,31 @@ test_that("Preserve column name when names_from column only has one unique value
   expect_named(out, c("Level", "Intercept", "abc"))
   expect_identical(nrow(out), 10L)
 })
+
+
+test_that("data_to_wide with multiple values_from and NA", {
+  long_df <- data.frame(
+    subject_id = rep(1:4, each = 2),
+    time = rep(c(1, 2), 4),
+    score = c(10, NA, 15, 12, 18, 11, NA, 14),
+    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
+  )
+
+  out <- data_to_wide(long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_from = c("score", "anxiety")
+  )
+
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = 1:4,
+      anxiety_1 = c(5, 6, 8, 5),
+      anxiety_2 = c(7, NA, 4, NA),
+      score_1 = c(10, 15, 18, NA),
+      score_2 = c(NA, 12, 11, 14)
+    ),
+    ignore_attr = TRUE
+  )
+})

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -560,29 +560,30 @@ test_that("Preserve column name when names_from column only has one unique value
 })
 
 
-test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
-  long_df <- data.frame(
-    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
-    time = rep(c(1, 2), 4),
-    score = c(10, NA, 15, 12, 18, 11, NA, 14),
-    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
-  )
+# test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
+#   long_df <- data.frame(
+#     subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
+#     time = rep(c(1, 2), 4),
+#     score = c(10, NA, 15, 12, 18, 11, NA, 14),
+#     anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
+#   )
 
-  out <- data_to_wide(long_df,
-    id_cols = "subject_id",
-    names_from = "time",
-    values_from = c("score", "anxiety")
-  )
+#   out <- data_to_wide(
+#     long_df,
+#     id_cols = "subject_id",
+#     names_from = "time",
+#     values_from = c("score", "anxiety")
+#   )
 
-  expect_equal(
-    out,
-    data.frame(
-      subject_id = c(1, 2, 3, 5, 4),
-      score.1 = c(10, 15, 18, NA, NA),
-      anxiety.1 = c(5, 6, 8, NA, 5),
-      score.2 = c(NA, 12, NA, 11, 14),
-      anxiety.2 = c(7, NA, NA, 4, NA)
-    ),
-    ignore_attr = TRUE
-  )
-})
+#   expect_equal(
+#     out,
+#     data.frame(
+#       subject_id = c(1, 2, 3, 5, 4),
+#       score.1 = c(10, 15, 18, NA, NA),
+#       anxiety.1 = c(5, 6, 8, NA, 5),
+#       score.2 = c(NA, 12, NA, 11, 14),
+#       anxiety.2 = c(7, NA, NA, 4, NA)
+#     ),
+#     ignore_attr = TRUE
+#   )
+# })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -560,30 +560,27 @@ test_that("Preserve column name when names_from column only has one unique value
 })
 
 
-# test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
-#   long_df <- data.frame(
-#     subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
-#     time = rep(c(1, 2), 4),
-#     score = c(10, NA, 15, 12, 18, 11, NA, 14),
-#     anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
-#   )
+test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
+  skip_if_not_installed("tidyr")
+  
+  long_df <- tidyr::tibble(
+    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
+    time = rep(c(1, 2), 4),
+    score = c(10, NA, 15, 12, 18, 11, NA, 14),
+    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
+  )
 
-#   out <- data_to_wide(
-#     long_df,
-#     id_cols = "subject_id",
-#     names_from = "time",
-#     values_from = c("score", "anxiety")
-#   )
-
-#   expect_equal(
-#     out,
-#     data.frame(
-#       subject_id = c(1, 2, 3, 5, 4),
-#       score.1 = c(10, 15, 18, NA, NA),
-#       anxiety.1 = c(5, 6, 8, NA, 5),
-#       score.2 = c(NA, 12, NA, 11, 14),
-#       anxiety.2 = c(7, NA, NA, 4, NA)
-#     ),
-#     ignore_attr = TRUE
-#   )
-# })
+  tidyr <- tidyr::pivot_wider(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_from = c("score", "anxiety")
+  )
+  datawiz <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_from = c("score", "anxiety")
+  )
+  expect_identical(tidyr, datawiz)
+})

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -573,8 +573,8 @@ test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
   tidyr <- tidyr::pivot_wider(
     long_df,
     id_cols = "subject_id",
-    names_from = "time",
-    values_from = c("score", "anxiety")
+    names_from = time,
+    values_from = c(score, anxiety)
   )
   datawiz <- data_to_wide(
     long_df,

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -577,11 +577,11 @@ test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
   expect_equal(
     out,
     data.frame(
-      subject_id = 1:4,
-      anxiety_1 = c(5, 6, 8, 5),
-      anxiety_2 = c(7, NA, 4, NA),
-      score_1 = c(10, 15, 18, NA),
-      score_2 = c(NA, 12, 11, 14)
+      subject_id = c(1, 2, 3, 5, 4),
+      score.1 = c(10, 15, 18, NA, NA),
+      anxiety.1 = c(5, 6, 8, NA, 5),
+      score.2 = c(NA, 12, NA, 11, 14),
+      anxiety.2 = c(7, NA, NA, 4, NA)
     ),
     ignore_attr = TRUE
   )

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -560,9 +560,9 @@ test_that("Preserve column name when names_from column only has one unique value
 })
 
 
-test_that("data_to_wide with multiple values_from and NA", {
+test_that("data_to_wide with multiple values_from and non-symmetric IDs", {
   long_df <- data.frame(
-    subject_id = rep(1:4, each = 2),
+    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
     time = rep(c(1, 2), 4),
     score = c(10, NA, 15, 12, 18, 11, NA, 14),
     anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)


### PR DESCRIPTION
This example currently fails, which is fixed by this PR.

```r
long_df <- data.frame(
  subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
  time = rep(c(1, 2), 4),
  score = c(10, NA, 15, 12, 18, 11, NA, 14),
  anxiety = c(5, 7, 6, NA, 8, 4, 5, NA)
)

data_to_wide(long_df,
  id_cols = "subject_id",
  names_from = "time",
  values_from = c("score", "anxiety")
)
```
