### PR TITLE
Fix `values_fill`, docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.2.0.3
+Version: 1.2.0.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@ BUG FIXES
   (#644).
 
 * Fixed an issue in `data_to_wide()` when `values_fill` was specified and
-  multiple variables were assigned in `values_from`.
+  multiple variables were assigned in `values_from` (#645).
 
 # datawizard 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@ BUG FIXES
   `values_from` when IDs were not balanced (equally spread across observations)
   (#644).
 
+* Fixed an issue in `data_to_wide()` when `values_fill` was specified and
+  multiple variables were assigned in `values_from`.
+
 # datawizard 1.2.0
 
 BREAKING CHANGES

--- a/R/data_separate.R
+++ b/R/data_separate.R
@@ -155,11 +155,20 @@ data_separate <- function(data,
   }
   # in case user did not provide names of new columns, we can try
   # to guess number of columns per variable
-  guess_columns <- match.arg(guess_columns, choices = c("min", "max", "mode"))
+  guess_columns <- insight::validate_argument(
+    guess_columns,
+    c("min", "max", "mode")
+  )
 
   # make sure we have valid options for fill and extra
-  fill <- match.arg(fill, choices = c("left", "right", "value_left", "value_right"))
-  extra <- match.arg(extra, choices = c("drop_left", "drop_right", "merge_left", "merge_right"))
+  fill <- insight::validate_argument(
+    fill,
+    c("left", "right", "value_left", "value_right")
+  )
+  extra <- insight::validate_argument(
+    extra,
+    c("drop_left", "drop_right", "merge_left", "merge_right")
+  )
 
   # evaluate select/exclude, may be select-helpers
   select <- .select_nse(select,

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -428,11 +428,11 @@ data_to_wide <- function(data,
 
     # replace if type exists
     if (is.numeric(fill) && any(vapply(values_from, function(vf) is.numeric(x[[vf]]), logical(1)))) {
-      x <- convert_na_to(x, replace_num = values_fill)
+      x <- convert_na_to(x, replace_num = values_fill, verbose = FALSE)
     } else if (is.character(fill) && any(vapply(values_from, function(vf) is.character(x[[vf]]), logical(1)))) {
-      x <- convert_na_to(x, replace_char = values_fill)
+      x <- convert_na_to(x, replace_char = values_fill, verbose = FALSE)
     } else if (is.factor(fill) && any(vapply(values_from, function(vf) is.factor(x[[vf]]), logical(1)))) {
-        x <- convert_na_to(x, replace_fac = values_fill)
+        x <- convert_na_to(x, replace_fac = values_fill, verbose = FALSE)
     } else {
       insight::format_error("`values_fill` contains a value of unsupported type.")
     }

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -380,6 +380,8 @@ data_to_wide <- function(data,
       new_columns = id_cols,
       separator = "#dwid#"
     )
+    # restore types
+    df1 <- data_restoretype(df1, x)
   } else {
     colnames(df1)[colnames(df1) == ".datawizard_id"] <- id_cols
   }

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -428,7 +428,7 @@ data_to_wide <- function(data,
           insight::format_error(paste0("`values_fill` must be of type factor."))
         }
       } else if (verbose) {
-        insight::format_warning(
+        insight::format_error(
           "No missing values were filled, because either `values_from` contains variables of different types, or the type of `values_fill` is not supported."
         )
       }

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -428,11 +428,11 @@ data_to_wide <- function(data,
 
     # replace if type exists
     if (is.numeric(fill) && any(vapply(values_from, function(vf) is.numeric(x[[vf]]), logical(1)))) {
-      x <- convert_na_to(x, replace_num = values_fill, verbose = FALSE)
+      x <- convert_na_to(x, replace_num = fill, verbose = FALSE)
     } else if (is.character(fill) && any(vapply(values_from, function(vf) is.character(x[[vf]]), logical(1)))) {
-      x <- convert_na_to(x, replace_char = values_fill, verbose = FALSE)
+      x <- convert_na_to(x, replace_char = fill, verbose = FALSE)
     } else if (is.factor(fill) && any(vapply(values_from, function(vf) is.factor(x[[vf]]), logical(1)))) {
-        x <- convert_na_to(x, replace_fac = values_fill, verbose = FALSE)
+      x <- convert_na_to(x, replace_fac = fill, verbose = FALSE)
     } else {
       insight::format_error("`values_fill` contains a value of unsupported type.")
     }

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -33,11 +33,11 @@
 #' @param values_from The name of the columns in the original data that contains
 #' the values used to fill the new columns created in the widened data.
 #' @param values_fill Optionally, a (scalar) value that will be used to replace
-#' missing values in the new columns created. Note that if `values_from` has
-#' more than one variable, `values_fill` will be applied to all of them. Hence,
-#' all variables in `values_from` should be of the same type (e.g. all numeric).
-#' For more complex replacement rules, consider using [`convert_na_to()`] prior
-#' to widening the data.
+#' missing values in the new columns created (i.e. after widening the data).
+#' Note that if `values_from` has more than one variable, `values_fill` will be
+#' applied to all of them. Hence, all variables in `values_from` should be of
+#' the same type (e.g. all numeric). For more complex replacement rules,
+#' consider using [`convert_na_to()`] prior to widening the data.
 #' @param verbose Toggle warnings.
 #' @param ... Not used for now.
 #'

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -434,9 +434,11 @@ data_to_wide <- function(data,
     } else if (is.factor(fill) && any(vapply(values_from, function(vf) is.factor(x[[vf]]), logical(1)))) {
       x <- convert_na_to(x, replace_fac = fill, verbose = FALSE)
     } else {
-      insight::format_error(
-        "`values_fill` contains a value of unsupported type, or the type is not present in the variables from `values_from`."
-      )
+      insight::format_error(paste0(
+        "`values_fill` contains a value of unsupported type, or there are no ",
+        class(fill)[1],
+        "-variables in `values_from`."
+      ))
     }
   }
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -323,8 +323,6 @@ data_to_wide <- function(data,
   }
   row.names(out) <- NULL
 
-  out <- remove_empty_columns(out)
-
   # add back attributes where possible
   for (i in colnames(out)) {
     attributes(out[[i]]) <- variable_attr[[i]]

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -2,9 +2,7 @@
 #'
 #' This function "widens" data, increasing the number of columns and decreasing
 #' the number of rows. This is a dependency-free base-R equivalent of
-#' `tidyr::pivot_wider()`. A notable difference to `privot_wider()` is that
-#' empty columns (i.e., columns that contain only `NA` values after widening the
-#' data) are removed.
+#' `tidyr::pivot_wider()`.
 #'
 #' @param data A data frame to convert to wide format, so that it has more
 #' columns and fewer rows post-widening than pre-widening.
@@ -64,12 +62,6 @@
 #' In other words: repeated measurements, as indicated by `id_cols`, that are
 #' saved into the column `values_from` will be spread into new columns, which
 #' will be named after the values in `names_from`. See also 'Examples'.
-#'
-#' **Handling of empty columns**
-#'
-#' Empty columns (i.e., columns that contain only `NA` values after widening the
-#' data) are removed. This is a different behavior than in `tidyr::pivot_wider()`,
-#' which keeps empty columns.
 #'
 #' @examplesIf requireNamespace("lme4", quietly = TRUE)
 #' data_long <- read.table(header = TRUE, text = "

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -434,7 +434,9 @@ data_to_wide <- function(data,
     } else if (is.factor(fill) && any(vapply(values_from, function(vf) is.factor(x[[vf]]), logical(1)))) {
       x <- convert_na_to(x, replace_fac = fill, verbose = FALSE)
     } else {
-      insight::format_error("`values_fill` contains a value of unsupported type.")
+      insight::format_error(
+        "`values_fill` contains a value of unsupported type, or the type is not present in the variables from `values_from`."
+      )
     }
   }
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -415,7 +415,7 @@ data_to_wide <- function(data,
         } else {
           insight::format_error(paste0("`values_fill` must be of type numeric."))
         }
-      } else if (all(vapply(values_from, function(i) is.character(new_data[[i]]), logical(1)))) {
+      } else if (all(vapply(values_from, function(i) is.character(x[[i]]), logical(1)))) {
         if (is.character(values_fill)) {
           x <- convert_na_to(x, replace_char = values_fill)
         } else {
@@ -427,6 +427,10 @@ data_to_wide <- function(data,
         } else {
           insight::format_error(paste0("`values_fill` must be of type factor."))
         }
+      } else if (verbose) {
+        insight::format_warning(
+          "No missing values were filled, because either `values_from` contains variables of different types, or the type of `values_fill` is not supported."
+        )
       }
     } else if (verbose) {
       insight::format_error("`values_fill` must be of length 1.")

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -284,7 +284,7 @@ data_to_wide <- function(data,
 
 
   # Fill missing values (before converting to wide)
-  new_data <- .fill_missings(new_data, values_from, values_fill)
+  new_data <- .fill_missings(new_data, values_from, values_fill, verbose)
 
   # convert to wide format (returns the data and the order in which columns
   # should be ordered)
@@ -406,7 +406,7 @@ data_to_wide <- function(data,
 #'
 #' @noRd
 
-.fill_missings <- function(x, values_from, values_fill) {
+.fill_missings <- function(x, values_from, values_fill, verbose = TRUE) {
   if (!is.null(values_fill)) {
     if (length(values_fill) == 1L) {
       if (all(vapply(values_from, function(i) is.numeric(x[[i]]), logical(1)))) {

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -14,6 +14,8 @@ data_to_wide(
   names_prefix = "",
   names_glue = NULL,
   values_fill = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -27,6 +29,8 @@ reshape_wider(
   names_prefix = "",
   names_glue = NULL,
   values_fill = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -44,7 +48,8 @@ also be a character vector with more than one name of identifier columns. See
 also 'Details' and 'Examples'.}
 
 \item{values_from}{The name of the columns in the original data that contains
-the values used to fill the new columns created in the widened data.}
+the values used to fill the new columns created in the widened data. Can also
+be one of the selection helpers (see \code{\link[=data_select]{data_select()}}).}
 
 \item{names_from}{The name of the column in the original data whose values
 will be used for naming the new columns created in the widened data. Each

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -65,11 +65,12 @@ syntactic variable names.}
 \code{names_from} columns to create custom column names. Note that the only
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
 
-\item{values_fill}{Optionally, a (scalar) value that will be used to replace
-missing values in the new columns created (i.e. after widening the data).
-Note that if \code{values_from} has more than one variable, \code{values_fill} will be
-applied to all of them. Hence, all variables in \code{values_from} should be of
-the same type (e.g. all numeric). For more complex replacement rules,
+\item{values_fill}{Optionally, a (scalar) value, or a list of (scalar)
+values, that will be used to replace missing values in the new columns
+created (i.e. after widening the data). Note that missing values in the new
+columns will only be filled for matching types in \code{values_fill}, i.e.
+\code{values_fill = list(99, "99")} will replace missing values in numeric and
+character variables, but not for factors. For more complex replacement rules,
 consider using \code{\link[=convert_na_to]{convert_na_to()}} prior to widening the data.}
 
 \item{verbose}{Toggle warnings.}

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -65,13 +65,13 @@ syntactic variable names.}
 \code{names_from} columns to create custom column names. Note that the only
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
 
-\item{values_fill}{Optionally, a (scalar) value, or a list of (scalar)
-values, that will be used to replace missing values in the new columns
-created (i.e. after widening the data). Note that missing values in the new
-columns will only be filled for matching types in \code{values_fill}, i.e.
-\code{values_fill = list(99, "99")} will replace missing values in numeric and
-character variables, but not for factors. For more complex replacement rules,
-consider using \code{\link[=convert_na_to]{convert_na_to()}} prior to widening the data.}
+\item{values_fill}{Optionally, a (scalar) value, or a named list of (scalar)
+values, that will be used to create additional rows for missing combinations
+of \code{id_cols} and \code{names_from}, and then fills in the new columns with values
+from \code{values_from}. If a named list is provided, the names must correspond to
+the columns to be filled. Note that \code{values_fill} only applies to missing
+combinations of \code{id_cols} and \code{names_from}, i.e. if a combination exists but
+the value in \code{values_from} is \code{NA}, this will remain \code{NA}.}
 
 \item{verbose}{Toggle warnings.}
 

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -66,11 +66,11 @@ syntactic variable names.}
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
 
 \item{values_fill}{Optionally, a (scalar) value that will be used to replace
-missing values in the new columns created. Note that if \code{values_from} has
-more than one variable, \code{values_fill} will be applied to all of them. Hence,
-all variables in \code{values_from} should be of the same type (e.g. all numeric).
-For more complex replacement rules, consider using \code{\link[=convert_na_to]{convert_na_to()}} prior
-to widening the data.}
+missing values in the new columns created (i.e. after widening the data).
+Note that if \code{values_from} has more than one variable, \code{values_fill} will be
+applied to all of them. Hence, all variables in \code{values_from} should be of
+the same type (e.g. all numeric). For more complex replacement rules,
+consider using \code{\link[=convert_na_to]{convert_na_to()}} prior to widening the data.}
 
 \item{verbose}{Toggle warnings.}
 

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -84,9 +84,7 @@ tibble. Otherwise, it returns a data frame.
 \description{
 This function "widens" data, increasing the number of columns and decreasing
 the number of rows. This is a dependency-free base-R equivalent of
-\code{tidyr::pivot_wider()}. A notable difference to \code{privot_wider()} is that
-empty columns (i.e., columns that contain only \code{NA} values after widening the
-data) are removed.
+\code{tidyr::pivot_wider()}.
 }
 \details{
 Reshaping data into wide format usually means that the input data frame is
@@ -108,12 +106,6 @@ new columns that are created by \code{names_from}.
 In other words: repeated measurements, as indicated by \code{id_cols}, that are
 saved into the column \code{values_from} will be spread into new columns, which
 will be named after the values in \code{names_from}. See also 'Examples'.
-
-\strong{Handling of empty columns}
-
-Empty columns (i.e., columns that contain only \code{NA} values after widening the
-data) are removed. This is a different behavior than in \code{tidyr::pivot_wider()},
-which keeps empty columns.
 }
 \examples{
 \dontshow{if (requireNamespace("lme4", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -66,7 +66,11 @@ syntactic variable names.}
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
 
 \item{values_fill}{Optionally, a (scalar) value that will be used to replace
-missing values in the new columns created.}
+missing values in the new columns created. Note that if \code{values_from} has
+more than one variable, \code{values_fill} will be applied to all of them. Hence,
+all variables in \code{values_from} should be of the same type (e.g. all numeric).
+For more complex replacement rules, consider using \code{\link[=convert_na_to]{convert_na_to()}} prior
+to widening the data.}
 
 \item{verbose}{Toggle warnings.}
 
@@ -79,7 +83,9 @@ tibble. Otherwise, it returns a data frame.
 \description{
 This function "widens" data, increasing the number of columns and decreasing
 the number of rows. This is a dependency-free base-R equivalent of
-\code{tidyr::pivot_wider()}.
+\code{tidyr::pivot_wider()}. A notable difference to \code{privot_wider()} is that
+empty columns (i.e., columns that contain only \code{NA} values after widening the
+data) are removed.
 }
 \details{
 Reshaping data into wide format usually means that the input data frame is
@@ -101,6 +107,12 @@ new columns that are created by \code{names_from}.
 In other words: repeated measurements, as indicated by \code{id_cols}, that are
 saved into the column \code{values_from} will be spread into new columns, which
 will be named after the values in \code{names_from}. See also 'Examples'.
+
+\strong{Handling of empty columns}
+
+Empty columns (i.e., columns that contain only \code{NA} values after widening the
+data) are removed. This is a different behavior than in \code{tidyr::pivot_wider()},
+which keeps empty columns.
 }
 \examples{
 \dontshow{if (requireNamespace("lme4", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -96,7 +96,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "seen",
       values_fill = "a"
     ),
-    regexp = "value of unsupported type"
+    regexp = "character-variables"
   )
   expect_error(
     data_to_wide(
@@ -105,7 +105,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "seen",
       values_fill = factor("a")
     ),
-    regexp = "value of unsupported type"
+    regexp = "factor-variables"
   )
 
   ### Should be character
@@ -138,7 +138,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = 1
     ),
-    regexp = "value of unsupported type"
+    regexp = "numeric-variables"
   )
   expect_error(
     data_to_wide(
@@ -159,7 +159,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = "a"
     ),
-    regexp = "value of unsupported type"
+    regexp = "character-variables"
   )
   expect_error(
     data_to_wide(

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -635,4 +635,33 @@ test_that("data_to_wide with multiple values_from and values_fill works", {
     ),
     ignore_attr = TRUE
   )
+
+  long_df <- data.frame(
+    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
+    time = rep(c(1, 2), 4),
+    score = as.character(c(10, NA, 15, 12, 18, 11, NA, 14)),
+    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA),
+    test = rep(NA_real_, 8)
+  )
+
+  expect_warning(
+    data_to_wide(
+      long_df,
+      id_cols = "subject_id",
+      names_from = "time",
+      values_fill = 99,
+      values_from = c("score", "anxiety", "test")
+    ),
+    regex = "No missing values were filled"
+  )
+  expect_silent(
+    data_to_wide(
+      long_df,
+      id_cols = "subject_id",
+      names_from = "time",
+      values_fill = 99,
+      values_from = c("score", "anxiety", "test"),
+      verbose = FALSE
+    )
+  )
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -644,7 +644,7 @@ test_that("data_to_wide with multiple values_from and values_fill works", {
     test = rep(NA_real_, 8)
   )
 
-  expect_warning(
+  expect_error(
     data_to_wide(
       long_df,
       id_cols = "subject_id",

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -96,7 +96,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "seen",
       values_fill = "a"
     ),
-    regexp = "must be of type numeric"
+    regexp = "value of unsupported type"
   )
   expect_error(
     data_to_wide(
@@ -105,7 +105,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "seen",
       values_fill = factor("a")
     ),
-    regexp = "must be of type numeric"
+    regexp = "value of unsupported type"
   )
 
   ### Should be character
@@ -138,7 +138,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = 1
     ),
-    regexp = "must be of type character"
+    regexp = "value of unsupported type"
   )
   expect_error(
     data_to_wide(
@@ -147,7 +147,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = factor("a")
     ),
-    regexp = "must be of type character"
+    regexp = "value of unsupported type"
   )
 
   ### Should be factor
@@ -159,7 +159,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = "a"
     ),
-    regexp = "must be of type factor"
+    regexp = "value of unsupported type"
   )
   expect_error(
     data_to_wide(
@@ -168,7 +168,7 @@ test_that("data_to_wide, values_fill works", {
       values_from = "value",
       values_fill = 1
     ),
-    regexp = "must be of type factor"
+    regexp = "value of unsupported type"
   )
 })
 
@@ -180,7 +180,7 @@ test_that("data_to_wide, values_fill errors when length > 1", {
       tidyr::fish_encounters,
       names_from = "station",
       values_from = "seen",
-      values_fill = c(1, 2)
+      values_fill = list(c(1, 2))
     ),
     regexp = "must be of length 1"
   )
@@ -635,33 +635,33 @@ test_that("data_to_wide with multiple values_from and values_fill works", {
     ),
     ignore_attr = TRUE
   )
+})
 
+
+test_that("data_to_wide with values_from and values_fill length > 1", {
   long_df <- data.frame(
     subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
     time = rep(c(1, 2), 4),
-    score = as.character(c(10, NA, 15, 12, 18, 11, NA, 14)),
-    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA),
-    test = rep(NA_real_, 8)
+    score = c(10, NA, 15, 12, 18, 11, NA, 14),
+    anxiety = as.character(c(5, 7, 6, NA, 8, 4, 5, NA)),
+    test = rep(NA_real_, 8),
+    stringsAsFactors = FALSE
   )
 
-  expect_error(
-    data_to_wide(
-      long_df,
-      id_cols = "subject_id",
-      names_from = "time",
-      values_fill = 99,
-      values_from = c("score", "anxiety", "test")
-    ),
-    regex = "No missing values were filled"
+  out <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_fill = 99,
+    values_from = c("score", "anxiety", "test")
   )
-  expect_silent(
-    data_to_wide(
-      long_df,
-      id_cols = "subject_id",
-      names_from = "time",
-      values_fill = 99,
-      values_from = c("score", "anxiety", "test"),
-      verbose = FALSE
-    )
+
+  out <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_fill = list(99, "ninety-nine"),
+    values_from = c("score", "anxiety", "test")
   )
+
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -655,6 +655,20 @@ test_that("data_to_wide with values_from and values_fill length > 1", {
     values_fill = 99,
     values_from = c("score", "anxiety", "test")
   )
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = c(1, 2, 3, 5, 4),
+      score_1 = c(10, 15, 18, 99, 99),
+      score_2 = c(99, 12, 99, 11, 14),
+      anxiety_1 = c("5", "6", "8", NA, "5"),
+      anxiety_2 = c("7", NA, NA, "4", NA),
+      test_1 = c(99, 99, 99, 99, 99),
+      test_2 = c(99, 99, 99, 99, 99),
+      stringsAsFactors = FALSE
+    ),
+    ignore_attr = TRUE
+  )
 
   out <- data_to_wide(
     long_df,
@@ -663,5 +677,18 @@ test_that("data_to_wide with values_from and values_fill length > 1", {
     values_fill = list(99, "ninety-nine"),
     values_from = c("score", "anxiety", "test")
   )
-
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = c(1, 2, 3, 5, 4),
+      score_1 = c(10, 15, 18, 99, 99),
+      score_2 = c(99, 12, 99, 11, 14),
+      anxiety_1 = c("5", "6", "8", "ninety-nine", "5"),
+      anxiety_2 = c("7", "ninety-nine", "ninety-nine", "4", "ninety-nine"),
+      test_1 = c(99, 99, 99, 99, 99),
+      test_2 = c(99, 99, 99, 99, 99),
+      stringsAsFactors = FALSE
+    ),
+    ignore_attr = TRUE
+  )
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -584,3 +584,55 @@ test_that("data_to_wide with multiple values_from and unbalanced panel", {
   )
   expect_identical(tidyr, datawiz)
 })
+
+
+test_that("data_to_wide with multiple values_from and values_fill works", {
+  long_df <- data.frame(
+    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
+    time = rep(c(1, 2), 4),
+    score = c(10, NA, 15, 12, 18, 11, NA, 14),
+    anxiety = c(5, 7, 6, NA, 8, 4, 5, NA),
+    test = rep(NA_real_, 8)
+  )
+
+  out <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_fill = 99,
+    values_from = c("score", "anxiety", "test")
+  )
+
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = c(1, 2, 3, 5, 4),
+      score_1 = c(10, 15, 18, 99, 99),
+      score_2 = c(99, 12, 99, 11, 14),
+      anxiety_1 = c(5, 6, 8, 99, 5),
+      anxiety_2 = c(7, 99, 99, 4, 99),
+      test_1 = c(99, 99, 99, 99, 99),
+      test_2 = c(99, 99, 99, 99, 99)
+    ),
+    ignore_attr = TRUE
+  )
+
+  out <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_from = c("score", "anxiety", "test")
+  )
+
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = c(1, 2, 3, 5, 4),
+      score_1 = c(10, 15, 18, NA, NA),
+      score_2 = c(NA, 12, NA, 11, 14),
+      anxiety_1 = c(5, 6, 8, NA, 5),
+      anxiety_2 = c(7, NA, NA, 4, NA)
+    ),
+    ignore_attr = TRUE
+  )
+})


### PR DESCRIPTION
This `PR`:
- fixes `values_fill` when `values_from` > 1
- allows `values_fill` to be a list of mixed types
- refactors the missing-fill code into a separate function
- adds docs about different behaviour of `data_to_wide()` and `pivot_wider()`.