### PR TITLE
`data_to_wide()`: disable arg `values_fill`, do not drop empty columns, allow select helpers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.2.0.3
+Version: 1.2.0.4
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ CHANGES
 * Due to changes in the package `insight`, `data_tabulate()` no longer prints
   decimals when all values in a column are integers (#641).
 
+* Argument `values_from` in `data_to_wide()` now supports select-helpers like
+  the `select` argument in other `{datawizard}` functions (#645).
+
 BUG FIXES
 
 * Fixed an issue when `demean()`ing nested structures with more than 2 grouping

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # datawizard (development)
 
+BREAKING CHANGES
+
+* Argument `values_fill` in `data_to_wide()` is now defunct, because it did not
+  work as intended (#645).
+
 CHANGES
 
 * Due to changes in the package `insight`, `data_tabulate()` no longer prints

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@ BREAKING CHANGES
 * Argument `values_fill` in `data_to_wide()` is now defunct, because it did not
   work as intended (#645).
 
+* `data_to_wide()` no longer removes empty columns that were created after
+  widening data frames, to behave similar to `tidyr::pivot_wider()` (#645).
+
 CHANGES
 
 * Due to changes in the package `insight`, `data_tabulate()` no longer prints

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ BREAKING CHANGES
   work as intended (#645).
 
 * `data_to_wide()` no longer removes empty columns that were created after
-  widening data frames, to behave similar to `tidyr::pivot_wider()` (#645).
+  widening data frames, to behave similarly to `tidyr::pivot_wider()` (#645).
 
 CHANGES
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -218,7 +218,7 @@ data_to_wide <- function(data,
     id_cols <- setdiff(colnames(data), c(names_from, values_from))
   } else if (!all(id_cols %in% colnames(data))) {
     insight::format_error(
-      "`id_cols` must be the name of an existing column in `data`."
+      "`id_cols` must be the names of existing columns in `data`."
     )
   }
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -170,7 +170,8 @@ data_to_wide <- function(
   # validate arguments
   if (!is.null(values_fill)) {
     insight::format_warning(
-      "`values_fill` is defunct and has no function anymore. It will be removed in future versions."
+      "`values_fill` is defunct and has no function anymore. It will be removed in future versions.",
+      "To handle missing values after widening, use `convert_na_to()` instead."
     )
   }
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -110,6 +110,25 @@
 #'   names_glue = "prod_{product}_{country}"
 #' )
 #'
+#' # reshaping multiple long columns into wide format
+#' data_long <- read.table(header = TRUE, text = "
+#' subject_id time score anxiety test
+#'          1    1    10       5   NA
+#'          1    2    NA       7   NA
+#'          2    1    15       6   NA
+#'          2    2    12      NA   NA
+#'          3    1    18       8   NA
+#'          5    2    11       4   NA
+#'          4    1    NA       5   NA
+#'          4    2    14      NA   NA")
+#'
+#' data_to_wide(
+#'   data_long,
+#'   id_cols = "subject_id",
+#'   names_from = "time",
+#'   values_from = c("score", "anxiety", "test")
+#' )
+#'
 #' # using the "sleepstudy" dataset
 #' data(sleepstudy, package = "lme4")
 #'

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -30,7 +30,9 @@
 #' delimiters supported by `names_glue` are curly brackets, `{` and `}`.
 #' @param values_from The name of the columns in the original data that contains
 #' the values used to fill the new columns created in the widened data. Can also
-#' be one of the selection helpers (see argument `select` in [`data_select()`]).#'
+#' be one of the selection helpers (see argument `select` in [`data_select()`]).
+#' @param values_fill Defunct argument, which has no function anymore. Will be
+#' removed in future versions.
 #' @param verbose Toggle warnings.
 #' @param ... Not used for now.
 #'
@@ -157,11 +159,17 @@ data_to_wide <- function(data,
                          names_sep = "_",
                          names_prefix = "",
                          names_glue = NULL,
+                         values_fill = NULL,
                          ignore_case = FALSE,
                          regex = FALSE,
                          verbose = TRUE,
                          ...) {
   # validate arguments
+  if (!is.null(values_fill)) {
+    insight::format_warning(
+      "`values_fill` is defunct and has no function anymore. It will be removed in future versions."
+    )
+  }
 
   if (is.null(names_from) || !all(names_from %in% colnames(data))) {
     insight::format_error(
@@ -178,7 +186,7 @@ data_to_wide <- function(data,
   }
 
   values_from <- .select_nse(
-    values_from,
+    select = values_from,
     data,
     exclude = NULL,
     ignore_case,

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -167,7 +167,7 @@ data_to_wide <- function(
   verbose = TRUE,
   ...
 ) {
-  # validate arguments
+  ## TODO: remove in a future update (#645)
   if (!is.null(values_fill)) {
     insight::format_warning(
       "`values_fill` is defunct and has no function anymore. It will be removed in future versions.",

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -199,6 +199,12 @@ data_to_wide <- function(
     verbose = verbose
   )
 
+  if (is.null(values_from) || !length(values_from)) {
+    insight::format_error(
+      "No variable defined in `values_from` was found in the `data`."
+    )
+  }
+
   # save custom attributes
   custom_attr <- attributes(data)
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -179,14 +179,6 @@ data_to_wide <- function(data,
     )
   }
 
-  if (is.null(id_cols)) {
-    id_cols <- setdiff(colnames(data), c(names_from, values_from))
-  } else if (!all(id_cols %in% colnames(data))) {
-    insight::format_error(
-      "`id_cols` must be the name of an existing column in `data`."
-    )
-  }
-
   select <- substitute(values_from)
   values_from <- .select_nse(
     select,
@@ -200,6 +192,14 @@ data_to_wide <- function(data,
   if (is.null(values_from) || !length(values_from)) {
     insight::format_error(
       "No variable defined in `values_from` was found in the `data`."
+    )
+  }
+
+  if (is.null(id_cols)) {
+    id_cols <- setdiff(colnames(data), c(names_from, values_from))
+  } else if (!all(id_cols %in% colnames(data))) {
+    insight::format_error(
+      "`id_cols` must be the name of an existing column in `data`."
     )
   }
 

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -17,7 +17,10 @@
 #' will be used for naming the new columns created in the widened data. Each
 #' unique value in this column will become the name of one of these new columns.
 #' In case `names_prefix` is provided, column names will be concatenated with
-#' the string given in `names_prefix`.
+#' the string given in `names_prefix`. If `values_from` specifies more than one
+#' variable that should be widened, the new column names are a combination of
+#' the old column names in `values_from` and the *values* from `names_from`, to
+#' avoid duplicate column names.
 #' @param names_prefix String added to the start of every variable name. This is
 #'  particularly useful if `names_from` is a numeric vector and you want to create
 #'  syntactic variable names.
@@ -53,7 +56,7 @@
 #'   (`names_from`). Since these values may not necessarily reflect appropriate
 #'   column names, you can use `names_prefix` to add a prefix to each newly
 #'   created column name.
-#' - The name of the column that contains the values (`values_from`) for the
+#' - The name of the column(s) that contain the values (`values_from`) for the
 #'   new columns that are created by `names_from`.
 #'
 #' In other words: repeated measurements, as indicated by `id_cols`, that are
@@ -110,7 +113,9 @@
 #'   names_glue = "prod_{product}_{country}"
 #' )
 #'
-#' # reshaping multiple long columns into wide format
+#' # reshaping multiple long columns into wide format. to avoid duplicate
+#' # column names, new names are a combination of the old column names in
+#' # `values_from` and the values from `names_from`
 #' data_long <- read.table(header = TRUE, text = "
 #' subject_id time score anxiety test
 #'          1    1    10       5   NA

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -161,7 +161,7 @@ data_to_wide <- function(data,
                          regex = FALSE,
                          verbose = TRUE,
                          ...) {
-# validate arguments
+  # validate arguments
 
   if (is.null(names_from) || !all(names_from %in% colnames(data))) {
     insight::format_error(

--- a/R/data_to_wide.R
+++ b/R/data_to_wide.R
@@ -153,20 +153,18 @@
 #' )
 #' @inherit data_rename seealso
 #' @export
-data_to_wide <- function(
-  data,
-  id_cols = NULL,
-  values_from = "Value",
-  names_from = "Name",
-  names_sep = "_",
-  names_prefix = "",
-  names_glue = NULL,
-  values_fill = NULL,
-  ignore_case = FALSE,
-  regex = FALSE,
-  verbose = TRUE,
-  ...
-) {
+data_to_wide <- function(data,
+                         id_cols = NULL,
+                         values_from = "Value",
+                         names_from = "Name",
+                         names_sep = "_",
+                         names_prefix = "",
+                         names_glue = NULL,
+                         values_fill = NULL,
+                         ignore_case = FALSE,
+                         regex = FALSE,
+                         verbose = TRUE,
+                         ...) {
   ## TODO: remove in a future update (#645)
   if (!is.null(values_fill)) {
     insight::format_warning(
@@ -231,10 +229,7 @@ data_to_wide <- function(
   # create an id with all variables that are not in names_from or values_from
   # so that we can create missing combinations between this id and names_from
   if (length(id_cols) > 1L) {
-    new_data$temporary_id <- do.call(
-      paste,
-      c(new_data[, id_cols, drop = FALSE], sep = "_")
-    )
+    new_data$temporary_id <- do.call(paste, c(new_data[, id_cols, drop = FALSE], sep = "_"))
   } else if (length(id_cols) == 1L) {
     new_data$temporary_id <- new_data[[id_cols]]
   } else {
@@ -251,25 +246,19 @@ data_to_wide <- function(
 
   incomplete_groups <-
     (n_values_per_group > 1L &&
-      !all(
-        unique(n_rows_per_group) %in% insight::n_unique(new_data[, names_from])
-      )) ||
-    (n_values_per_group == 1L &&
-      unique(n_rows_per_group) < length(unique(new_data[, names_from])))
+      !all(unique(n_rows_per_group) %in% insight::n_unique(new_data[, names_from]))
+    ) ||
+      (n_values_per_group == 1L &&
+        unique(n_rows_per_group) < length(unique(new_data[, names_from]))
+      )
 
   # create missing combinations
 
   if (not_all_cols_are_selected && incomplete_groups) {
-    expanded <- expand.grid(
-      unique(new_data[["temporary_id"]]),
-      unique(new_data[[names_from]])
-    )
+    expanded <- expand.grid(unique(new_data[["temporary_id"]]), unique(new_data[[names_from]]))
     names(expanded) <- c("temporary_id", names_from)
-    new_data <- data_merge(
-      new_data,
-      expanded,
-      join = "full",
-      by = c("temporary_id", names_from),
+    new_data <- data_merge(new_data, expanded,
+      join = "full", by = c("temporary_id", names_from),
       sort = FALSE
     )
 
@@ -289,10 +278,8 @@ data_to_wide <- function(
     )
     lookup$temporary_id_2 <- seq_len(nrow(lookup))
     new_data <- data_merge(
-      new_data,
-      lookup,
-      by = "temporary_id",
-      join = "left"
+      new_data, lookup,
+      by = "temporary_id", join = "left"
     )
 
     # creation of missing combinations was done with a temporary id, so need
@@ -314,12 +301,8 @@ data_to_wide <- function(
   # convert to wide format (returns the data and the order in which columns
   # should be ordered)
   unstacked <- .unstack(
-    new_data,
-    names_from,
-    values_from,
-    names_sep,
-    names_prefix,
-    names_glue
+    new_data, names_from, values_from,
+    names_sep, names_prefix, names_glue
   )
 
   out <- unstacked$out
@@ -337,9 +320,7 @@ data_to_wide <- function(
       "Some values of the columns specified in `names_from` are already present as column names.",
       paste0(
         "Either use `names_prefix` or rename the following columns: ",
-        text_concatenate(current_colnames[which(
-          current_colnames %in% unstacked$col_order
-        )])
+        text_concatenate(current_colnames[which(current_colnames %in% unstacked$col_order)])
       )
     )
   }

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -55,7 +55,10 @@ be one of the selection helpers (see argument \code{select} in \code{\link[=data
 will be used for naming the new columns created in the widened data. Each
 unique value in this column will become the name of one of these new columns.
 In case \code{names_prefix} is provided, column names will be concatenated with
-the string given in \code{names_prefix}.}
+the string given in \code{names_prefix}. If \code{values_from} specifies more than one
+variable that should be widened, the new column names are a combination of
+the old column names in \code{values_from} and the \emph{values} from \code{names_from}, to
+avoid duplicate column names.}
 
 \item{names_sep}{If \code{names_from} or \code{values_from} contains multiple variables,
 this will be used to join their values together into a single string to use
@@ -112,7 +115,7 @@ necessary information for \code{data_to_wide()} is:
 (\code{names_from}). Since these values may not necessarily reflect appropriate
 column names, you can use \code{names_prefix} to add a prefix to each newly
 created column name.
-\item The name of the column that contains the values (\code{values_from}) for the
+\item The name of the column(s) that contain the values (\code{values_from}) for the
 new columns that are created by \code{names_from}.
 }
 
@@ -171,7 +174,9 @@ data_to_wide(
   names_glue = "prod_{product}_{country}"
 )
 
-# reshaping multiple long columns into wide format
+# reshaping multiple long columns into wide format. to avoid duplicate
+# column names, new names are a combination of the old column names in
+# `values_from` and the values from `names_from`
 data_long <- read.table(header = TRUE, text = "
 subject_id time score anxiety test
          1    1    10       5   NA

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -13,6 +13,7 @@ data_to_wide(
   names_sep = "_",
   names_prefix = "",
   names_glue = NULL,
+  values_fill = NULL,
   ignore_case = FALSE,
   regex = FALSE,
   verbose = TRUE,
@@ -27,6 +28,7 @@ reshape_wider(
   names_sep = "_",
   names_prefix = "",
   names_glue = NULL,
+  values_fill = NULL,
   ignore_case = FALSE,
   regex = FALSE,
   verbose = TRUE,
@@ -47,7 +49,7 @@ also 'Details' and 'Examples'.}
 
 \item{values_from}{The name of the columns in the original data that contains
 the values used to fill the new columns created in the widened data. Can also
-be one of the selection helpers (see argument \code{select} in \code{\link[=data_select]{data_select()}}).#'}
+be one of the selection helpers (see argument \code{select} in \code{\link[=data_select]{data_select()}}).}
 
 \item{names_from}{The name of the column in the original data whose values
 will be used for naming the new columns created in the widened data. Each
@@ -67,6 +69,9 @@ syntactic variable names.}
 \href{https://glue.tidyverse.org/index.html}{glue specification} that uses the
 \code{names_from} columns to create custom column names. Note that the only
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
+
+\item{values_fill}{Defunct argument, which has no function anymore. Will be
+removed in future versions.}
 
 \item{verbose}{Toggle warnings.}
 

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -13,7 +13,8 @@ data_to_wide(
   names_sep = "_",
   names_prefix = "",
   names_glue = NULL,
-  values_fill = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -26,7 +27,8 @@ reshape_wider(
   names_sep = "_",
   names_prefix = "",
   names_glue = NULL,
-  values_fill = NULL,
+  ignore_case = FALSE,
+  regex = FALSE,
   verbose = TRUE,
   ...
 )
@@ -44,7 +46,8 @@ also be a character vector with more than one name of identifier columns. See
 also 'Details' and 'Examples'.}
 
 \item{values_from}{The name of the columns in the original data that contains
-the values used to fill the new columns created in the widened data.}
+the values used to fill the new columns created in the widened data. Can also
+be one of the selection helpers (see argument \code{select} in \code{\link[=data_select]{data_select()}}).#'}
 
 \item{names_from}{The name of the column in the original data whose values
 will be used for naming the new columns created in the widened data. Each
@@ -64,9 +67,6 @@ syntactic variable names.}
 \href{https://glue.tidyverse.org/index.html}{glue specification} that uses the
 \code{names_from} columns to create custom column names. Note that the only
 delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \verb{\}}.}
-
-\item{values_fill}{Optionally, a (scalar) value that will be used to replace
-missing values in the new columns created.}
 
 \item{verbose}{Toggle warnings.}
 
@@ -193,16 +193,6 @@ data_to_wide(
   names_from = "Days",
   values_from = "Reaction",
   names_prefix = "Reaction_Day_"
-)
-
-# filling missing values with 0
-data_to_wide(
-  d,
-  id_cols = "Subject",
-  names_from = "Days",
-  values_from = "Reaction",
-  names_prefix = "Reaction_Day_",
-  values_fill = 0
 )
 \dontshow{\}) # examplesIf}
 }

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -73,6 +73,19 @@ delimiters supported by \code{names_glue} are curly brackets, \verb{\{} and \ver
 \item{values_fill}{Defunct argument, which has no function anymore. Will be
 removed in future versions.}
 
+\item{ignore_case}{Logical, if \code{TRUE} and when one of the select-helpers or
+a regular expression is used in \code{select}, ignores lower/upper case in the
+search pattern when matching against variable names.}
+
+\item{regex}{Logical, if \code{TRUE}, the search pattern from \code{select} will be
+treated as regular expression. When \code{regex = TRUE}, select \emph{must} be a
+character string (or a variable containing a character string) and is not
+allowed to be one of the supported select-helpers or a character vector
+of length > 1. \code{regex = TRUE} is comparable to using one of the two
+select-helpers, \code{select = contains()} or \code{select = regex()}, however,
+since the select-helpers may not work when called from inside other
+functions (see 'Details'), this argument may be used as workaround.}
+
 \item{verbose}{Toggle warnings.}
 
 \item{...}{Not used for now.}

--- a/man/data_to_wide.Rd
+++ b/man/data_to_wide.Rd
@@ -171,6 +171,25 @@ data_to_wide(
   names_glue = "prod_{product}_{country}"
 )
 
+# reshaping multiple long columns into wide format
+data_long <- read.table(header = TRUE, text = "
+subject_id time score anxiety test
+         1    1    10       5   NA
+         1    2    NA       7   NA
+         2    1    15       6   NA
+         2    2    12      NA   NA
+         3    1    18       8   NA
+         5    2    11       4   NA
+         4    1    NA       5   NA
+         4    2    14      NA   NA")
+
+data_to_wide(
+  data_long,
+  id_cols = "subject_id",
+  names_from = "time",
+  values_from = c("score", "anxiety", "test")
+)
+
 # using the "sleepstudy" dataset
 data(sleepstudy, package = "lme4")
 

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -519,7 +519,7 @@ test_that("data_to_wide, check for valid columns", {
       names_from = "time",
       values_from = c("score", "anxiety", "test")
     ),
-    regexp = "`id_cols` must be the name of",
+    regexp = "`id_cols` must be the names of",
     fixed = TRUE
   )
 
@@ -556,5 +556,37 @@ test_that("data_to_wide, check for valid columns", {
     ))),
     regexp = "No variable defined",
     fixed = TRUE
+  )
+})
+
+
+test_that("data_to_wide, select helper for values_from", {
+  long_df <- data.frame(
+    subject_id = c(1, 1, 2, 2, 3, 5, 4, 4),
+    time = rep(c(1, 2), 4),
+    score_a = c(10, NA, 15, 12, 18, 11, NA, 14),
+    score_b = c(5, 7, 6, NA, 8, 4, 5, NA),
+    score_c = rep(NA_real_, 8)
+  )
+
+  out <- data_to_wide(
+    long_df,
+    id_cols = "subject_id",
+    names_from = "time",
+    values_from = starts_with("score_")
+  )
+
+  expect_equal(
+    out,
+    data.frame(
+      subject_id = c(1, 2, 3, 5, 4),
+      score_a_1 = c(10, 15, 18, NA, NA),
+      score_a_2 = c(NA, 12, NA, 11, 14),
+      score_a_1 = c(5, 6, 8, NA, 5),
+      score_a_2 = c(7, NA, NA, 4, NA),
+      score_a_1 = as.double(c(NA, NA, NA, NA, NA)),
+      score_a_2 = as.double(c(NA, NA, NA, NA, NA))
+    ),
+    ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -544,4 +544,17 @@ test_that("data_to_wide, check for valid columns", {
     regex = "Following variable(s) were not found",
     fixed = TRUE
   )
+
+  expect_error(
+    expect_warning(expect_warning(expect_warning(
+      data_to_wide(
+        long_df,
+        id_cols = "subject_id",
+        names_from = "time",
+        values_from = c("a", "b", "c")
+      )
+    ))),
+    regex = "No variable defined",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-data_to_wide.R
+++ b/tests/testthat/test-data_to_wide.R
@@ -519,7 +519,7 @@ test_that("data_to_wide, check for valid columns", {
       names_from = "time",
       values_from = c("score", "anxiety", "test")
     ),
-    regex = "`id_cols` must be the name of",
+    regexp = "`id_cols` must be the name of",
     fixed = TRUE
   )
 
@@ -530,7 +530,7 @@ test_that("data_to_wide, check for valid columns", {
       names_from = "times",
       values_from = c("score", "anxiety", "test")
     ),
-    regex = "`names_from` must be the name of",
+    regexp = "`names_from` must be the name of",
     fixed = TRUE
   )
 
@@ -541,7 +541,7 @@ test_that("data_to_wide, check for valid columns", {
       names_from = "time",
       values_from = c("scores", "anxiety", "test")
     ),
-    regex = "Following variable(s) were not found",
+    regexp = "Following variable(s) were not found",
     fixed = TRUE
   )
 
@@ -554,7 +554,7 @@ test_that("data_to_wide, check for valid columns", {
         values_from = c("a", "b", "c")
       )
     ))),
-    regex = "No variable defined",
+    regexp = "No variable defined",
     fixed = TRUE
   )
 })

--- a/vignettes/tidyverse_translation.Rmd
+++ b/vignettes/tidyverse_translation.Rmd
@@ -738,8 +738,7 @@ fish_encounters
 fish_encounters |>
   data_to_wide(
     names_from = "station",
-    values_from = "seen",
-    values_fill = 0
+    values_from = "seen"
   )
 ```
 :::
@@ -751,8 +750,7 @@ fish_encounters |>
 fish_encounters |>
   pivot_wider(
     names_from = station,
-    values_from = seen,
-    values_fill = 0
+    values_from = seen
   )
 ```
 :::


### PR DESCRIPTION
- No longer removes widened columns when these were NA only
- Remove `values_fill` argument, as this never worked as probably intended
- allow select-helpers for `values_from`
- validate input arguments

This one replaces #645