### PR TITLE
Improve performance by using `tryCatch()` instead of `try()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: datawizard
 Title: Easy Data Wrangling and Statistical Transformations
-Version: 1.2.0.7
+Version: 1.2.0.8
 Authors@R: c(
     person("Indrajeet", "Patil", , "patilindrajeet.science@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0003-1995-6531")),

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -354,7 +354,7 @@ data_filter.grouped_df <- function(x, ...) {
   # can identify a function call, and only continue checking for wrong syntax
   # when we have not identified a function.
 
-  if (!is.function(try(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), silent = TRUE))) {
+  if (!is.function(tryCatch(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), error = function(e) NULL))) {
     # Give more informative message to users
     # about possible misspelled comparisons / logical conditions
     # check if "=" instead of "==" was used?

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -354,7 +354,7 @@ data_filter.grouped_df <- function(x, ...) {
   # can identify a function call, and only continue checking for wrong syntax
   # when we have not identified a function.
 
-  if (!is.function(tryCatch(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), error = function(e) NULL))) {
+  if (!is.function(try(get(gsub("^(.*?)\\((.*)", "\\1", tmp)), silent = TRUE))) {
     # Give more informative message to users
     # about possible misspelled comparisons / logical conditions
     # check if "=" instead of "==" was used?

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -426,11 +426,11 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
       symbol_string <- .fix_quotes(symbol_string)
       symbol_name <- names(dots)[i]
       # convert string into language and replace in dots
-      return_value <- try(str2lang(symbol_string), silent = TRUE)
+      return_value <- tryCatch(str2lang(symbol_string), error = function(e) NULL)
       # sanity check - for invalid expressions, like
       # data_modify(iris, a = as_expr(c("1 + 1", "2 + 2")))
       # we get an error here
-      if (inherits(return_value, "try-error")) {
+      if (is.null(return_value)) {
         insight::format_error(paste0(
           "Could not evaluate expression `", symbol_string[1], "`. ",
           "Please check if it's correctly specified. If you think there's a bug ",
@@ -559,12 +559,12 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
   } else if (!is.null(symbol_string) && length(symbol_string) == 1 && grepl("\\bn\\(\\)", symbol_string)) {
     # "special" functions, like "1:n()" or similar - but not "1:fun()"
     symbol_string <- str2lang(gsub("n()", "nrow(data)", symbol_string, fixed = TRUE))
-    new_variable <- try(with(data, eval(symbol_string)), silent = TRUE)
+    new_variable <- tryCatch(with(data, eval(symbol_string)), error = function(e) NULL)
   } else {
     # evaluate symbol
-    new_variable <- try(with(data, eval(symbol)), silent = TRUE)
+    new_variable <- tryCatch(with(data, eval(symbol)), error = function(e) NULL)
     # if evaluation fails, we have a value - and directly use it
-    if (inherits(new_variable, "try-error") && !is.null(eval_symbol)) {
+    if (is.null(new_variable) && !is.null(eval_symbol)) {
       new_variable <- eval_symbol
     }
   }

--- a/R/data_modify.R
+++ b/R/data_modify.R
@@ -426,11 +426,11 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
       symbol_string <- .fix_quotes(symbol_string)
       symbol_name <- names(dots)[i]
       # convert string into language and replace in dots
-      return_value <- tryCatch(str2lang(symbol_string), error = function(e) NULL)
+      return_value <- try(str2lang(symbol_string), silent = TRUE)
       # sanity check - for invalid expressions, like
       # data_modify(iris, a = as_expr(c("1 + 1", "2 + 2")))
       # we get an error here
-      if (is.null(return_value)) {
+      if (inherits(return_value, "try-error")) {
         insight::format_error(paste0(
           "Could not evaluate expression `", symbol_string[1], "`. ",
           "Please check if it's correctly specified. If you think there's a bug ",
@@ -559,12 +559,12 @@ data_modify.grouped_df <- function(data, ..., .if = NULL, .at = NULL, .modify = 
   } else if (!is.null(symbol_string) && length(symbol_string) == 1 && grepl("\\bn\\(\\)", symbol_string)) {
     # "special" functions, like "1:n()" or similar - but not "1:fun()"
     symbol_string <- str2lang(gsub("n()", "nrow(data)", symbol_string, fixed = TRUE))
-    new_variable <- tryCatch(with(data, eval(symbol_string)), error = function(e) NULL)
+    new_variable <- try(with(data, eval(symbol_string)), silent = TRUE)
   } else {
     # evaluate symbol
-    new_variable <- tryCatch(with(data, eval(symbol)), error = function(e) NULL)
+    new_variable <- try(with(data, eval(symbol)), silent = TRUE)
     # if evaluation fails, we have a value - and directly use it
-    if (is.null(new_variable) && !is.null(eval_symbol)) {
+    if (inherits(new_variable, "try-error") && !is.null(eval_symbol)) {
       new_variable <- eval_symbol
     }
   }

--- a/R/select_nse.R
+++ b/R/select_nse.R
@@ -236,6 +236,10 @@
 # it is a select helper that we grab from the error message.
 
 .select_symbol <- function(data, x, ignore_case, regex, verbose, ifnotfound) {
+  # We use `tryCatch()` instead of `try()` here, because for grouped data frame
+  # methods, `.dynEval()` can be called many times. Since `tryCatch()` is minimal
+  # faster than `try()`, we get a performance "boost" of some seconds for large
+  # data frames with many groups (see https://github.com/easystats/datawizard/pull/657/)
   try_eval <- tryCatch(eval(x), error = function(e) NULL)
   x_dep <- insight::safe_deparse(x)
   is_select_helper <- FALSE
@@ -632,6 +636,10 @@
       n <- n - 1L
       env <- sys.frame(n)
     }
+    # We use `tryCatch()` instead of `try()` here, because for grouped data frame
+    # methods, `.dynEval()` can be called many times. Since `tryCatch()` is minimal
+    # faster than `try()`, we get a performance "boost" of some seconds for large
+    # data frames with many groups (see https://github.com/easystats/datawizard/pull/657/)
     r <- tryCatch(eval(str2lang(x), envir = env), error = function(e) NULL)
     if (!is.null(r)) {
       return(r)

--- a/R/select_nse.R
+++ b/R/select_nse.R
@@ -236,7 +236,7 @@
 # it is a select helper that we grab from the error message.
 
 .select_symbol <- function(data, x, ignore_case, regex, verbose, ifnotfound) {
-  try_eval <- try(eval(x), silent = TRUE)
+  try_eval <- tryCatch(eval(x), error = function(e) NULL)
   x_dep <- insight::safe_deparse(x)
   is_select_helper <- FALSE
   out <- NULL
@@ -632,8 +632,8 @@
       n <- n - 1L
       env <- sys.frame(n)
     }
-    r <- try(eval(str2lang(x), envir = env), silent = TRUE)
-    if (!inherits(r, "try-error") && !is.null(r)) {
+    r <- tryCatch(eval(str2lang(x), envir = env), error = function(e) NULL)
+    if (!is.null(r)) {
       return(r)
     }
   }


### PR DESCRIPTION
Both when evaluation succeeds or fails, `tryCatch()` is faster than `try()`. This can be beneficial when we have repeated calls to function, e.g. for grouped data frames.

``` r
microbenchmark::microbenchmark(
  try(x <- 1, silent = TRUE),
  tryCatch(x <- 1, error = function(e) NULL),
  times = 1000
)
#> Unit: microseconds
#>                                        expr   min    lq     mean median    uq
#>                  try(x <- 1, silent = TRUE) 6.100 6.401 7.846637  6.601 7.101
#>  tryCatch(x <- 1, error = function(e) NULL) 5.701 6.001 7.157679  6.201 6.700
#>      max neval cld
#>  220.501  1000  a 
#>   58.600  1000   b
microbenchmark::microbenchmark(
  try(x <- a, silent = TRUE),
  tryCatch(x <- a, error = function(e) NULL),
  times = 1000
)
#> Unit: microseconds
#>                                        expr    min      lq      mean  median
#>                  try(x <- a, silent = TRUE) 87.202 92.2010 105.88034 99.3505
#>  tryCatch(x <- a, error = function(e) NULL) 29.201 31.4015  35.81722 33.5015
#>        uq     max neval cld
#>  110.4015 352.901  1000  a 
#>   36.3010 172.801  1000   b
```

<sup>Created on 2025-09-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

In a recent code, I had speed improvement of ~4 seconds - however, the major bottleneck when _datawizard_ deals with grouped df is that we just call the `.data.frame` method repeatedly. In the long run, we might think about writing loops inside the `.data.frame` method for grouped df's instead of repeatedly calling it.

I found this for `data_filter()`, where the profiling showed that `.dynEval()` slows down the filtering:

```r
  for (i in seq_along(dots)) {
    # only proceed when result is still valid
    if (!is.null(out)) {
      symbol <- dots[[i]]
      # evaluate, we may have a variable with filter expression
      eval_symbol <- .dynEval(symbol, ifnotfound = NULL)
      # validation check: is variable named like a function?
      if (is.function(eval_symbol)) {
        eval_symbol <- .dynGet(symbol, ifnotfound = NULL)
      }
...
```

Maybe we can re-write the code so that dots are evaluated first, and then we filter on subsets of grouped df in the above code?!? But that's not part of this PR.

My idea, roughly:

```r
  for (i in seq_along(dots)) {
    # only proceed when result is still valid
    if (!is.null(out)) {
      symbol <- dots[[i]]
      # evaluate, we may have a variable with filter expression
      eval_symbol <- .dynEval(symbol, ifnotfound = NULL)

# after evaluating symbol, we now split a grouped data frame
# into subsets and do not repeatedly
# evaluate the dots for each subset of the grouped df.
```
