### PR TITLE
Fix failing test due to change in R-devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ CHANGES
   `.rds`, and `.rdata`). Data encryption is based on the AES-GCM algorithm using
   the `openssl::aes_gcm_encrypt()` function (#675).
 
+FIXES
+
+* Fix a test due to R-devel change (#677).
+
 # datawizard 1.3.0
 
 BREAKING CHANGES

--- a/R/data_match.R
+++ b/R/data_match.R
@@ -269,7 +269,7 @@ data_filter.data.frame <- function(x, ...) {
         )
       }
 
-      if (inherits(out, "simpleError")) {
+      if (inherits(out, c("simpleError", "objectNotFoundError"))) {
         error_msg <- out$message[1]
         # try to find out which variable was the cause for the error
         if (grepl("object '(.*)' not found", error_msg)) {


### PR DESCRIPTION
Fixes #676 

Example of failing test:

```r
expect_error(
    data_filter(mtcars, mpg > 10?cyl == 4),
    "syntax"
  )
```