### PR TITLE
Fix params in `contr.deviation()`

### DIFF
--- a/R/contrs.R
+++ b/R/contrs.R
@@ -7,8 +7,8 @@
 #'  baseline group. Ignored if `contrasts` is `FALSE`.
 #' @param contrasts description
 #' @param sparse logical indicating if the result should be sparse
-#' (of class [`Matrix`](linkS4class(dgCMatrix)), using
-#' package CRANpkg(Matrix).
+#' (of class \code{\link[Matrix]{dgCMatrix-class}}), using
+#' package \code{\link{Matrix}}.
 #'
 #' @details
 #' In effects coding, unlike treatment/dummy coding

--- a/R/contrs.R
+++ b/R/contrs.R
@@ -2,7 +2,13 @@
 #'
 #' Build a deviation contrast matrix, a type of _effects contrast_ matrix.
 #'
-#' @inheritParams stats::contr.sum
+#' @param n a vector of levels for a factor, or the number of levels.
+#' @param base an integer specifying which group is considered the
+#'  baseline group. Ignored if `contrasts` is `FALSE`.
+#' @param contrasts description
+#' @param sparse logical indicating if the result should be sparse
+#' (of class [`Matrix`](linkS4class(dgCMatrix)), using
+#' package CRANpkg(Matrix).
 #'
 #' @details
 #' In effects coding, unlike treatment/dummy coding

--- a/R/data_tabulate.R
+++ b/R/data_tabulate.R
@@ -39,6 +39,10 @@
 #' printed as markdown or HTML table, depending on the environment. See
 #' [`insight::export_table()`] for details.
 #' @param verbose Toggle warnings and messages.
+#' @param measures Optional character vector, indicating the types of
+#' percents to be included. Only applies to frequencies, i.e. when `by` is
+#' `NULL`. Can be `"raw"` (includes `NA` values), `"valid"` (excludes `NA` values)
+#' or `"cumulative"` (excludes `NA` vlues).
 #' @param ... not used.
 #' @inheritParams extract_column_names
 #'
@@ -154,6 +158,7 @@ data_tabulate.default <- function(
   proportions = NULL,
   name = NULL,
   verbose = TRUE,
+  measures = c("raw", "valid", "cumulative"),
   ...
 ) {
   # save label attribute, before it gets lost...
@@ -250,7 +255,9 @@ data_tabulate.default <- function(
     out$N <- round(out$N)
   }
 
-  out$`Raw %` <- 100 * out$N / sum(out$N)
+  if ("raw" %in% measures){
+    out$`Raw %` <- 100 * out$N / sum(out$N)
+  }
   # if we have missing values, we add a row with NA
   if (remove_na) {
     out$`Valid %` <- 100 * out$N / sum(out$N)
@@ -259,8 +266,14 @@ data_tabulate.default <- function(
     out$`Valid %` <- c(100 * out$N[-nrow(out)] / sum(out$N[-nrow(out)]), NA)
     valid_n <- sum(out$N[-length(out$N)], na.rm = TRUE)
   }
-  out$`Cumulative %` <- cumsum(out$`Valid %`)
 
+  if ("cumulative" %in% measures) {
+    out$`Cumulative %` <- cumsum(out$`Valid %`)
+  }
+
+  if (!"valid" %in% measures) {
+     out$`Valid %` <- NULL
+  }
   # add information about variable/group names
   if (!is.null(obj_name)) {
     if (is.null(group_variable)) {

--- a/man/contr.deviation.Rd
+++ b/man/contr.deviation.Rd
@@ -10,25 +10,24 @@ contr.deviation(n, base = 1, contrasts = TRUE, sparse = FALSE)
 \item{n}{a vector of levels for a factor, or the number of levels.}
 
 \item{base}{an integer specifying which group is considered the
-    baseline group. Ignored if \code{contrasts} is \code{FALSE}.}
+baseline group. Ignored if \code{contrasts} is \code{FALSE}.}
 
-\item{contrasts}{a logical indicating whether contrasts should be
-    computed.}
+\item{contrasts}{description}
 
 \item{sparse}{logical indicating if the result should be sparse
-    (of class \code{\linkS4class[Matrix]{dgCMatrix}}), using
-    package \href{https://CRAN.R-project.org/package=Matrix}{\pkg{Matrix}}.}
+(of class \href{linkS4class(dgCMatrix)}{\code{Matrix}}, using
+package CRANpkg(Matrix).}
 }
 \description{
 Build a deviation contrast matrix, a type of \emph{effects contrast} matrix.
 }
 \details{
 In effects coding, unlike treatment/dummy coding
-(\code{\link[stats:contrast]{stats::contr.treatment()}}), each contrast sums to 0. In regressions models,
+(\code{\link[stats:contr.treatment]{stats::contr.treatment()}}), each contrast sums to 0. In regressions models,
 this results in an intercept that represents the (unweighted) average of the
 group means. In ANOVA settings, this also guarantees that lower order effects
 represent \emph{main} effects (and not \emph{simple} or \emph{conditional} effects, as is
-the case when using R's default \code{\link[stats:contrast]{stats::contr.treatment()}}).
+the case when using R's default \code{\link[stats:contr.treatment]{stats::contr.treatment()}}).
 \cr\cr
 Deviation coding (\code{contr.deviation}) is a type of effects coding. With
 deviation coding, the coefficients for factor variables are interpreted as
@@ -39,7 +38,7 @@ represents the overall mean (average of the group means for the 3 groups),
 and the coefficients \code{groupB} and \code{groupC} represent the differences between
 the A group mean and the B and C group means, respectively.
 \cr\cr
-Sum coding (\code{\link[stats:contrast]{stats::contr.sum()}}) is another type of effects coding. With sum
+Sum coding (\code{\link[stats:contr.sum]{stats::contr.sum()}}) is another type of effects coding. With sum
 coding, the coefficients for factor variables are interpreted as the
 difference of each factor level from \strong{the grand (across-groups) mean}. For
 example, for a factor \code{group} with levels "A", "B", and "C", with
@@ -101,5 +100,5 @@ solve(mm)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[stats:contrast]{stats::contr.sum()}}
+\code{\link[stats:contr.sum]{stats::contr.sum()}}
 }

--- a/man/contr.deviation.Rd
+++ b/man/contr.deviation.Rd
@@ -15,8 +15,8 @@ baseline group. Ignored if \code{contrasts} is \code{FALSE}.}
 \item{contrasts}{description}
 
 \item{sparse}{logical indicating if the result should be sparse
-(of class \href{linkS4class(dgCMatrix)}{\code{Matrix}}, using
-package CRANpkg(Matrix).}
+(of class \code{\link[Matrix]{dgCMatrix-class}}), using
+package \code{\link{Matrix}}.}
 }
 \description{
 Build a deviation contrast matrix, a type of \emph{effects contrast} matrix.

--- a/man/data_tabulate.Rd
+++ b/man/data_tabulate.Rd
@@ -19,6 +19,7 @@ data_tabulate(x, ...)
   proportions = NULL,
   name = NULL,
   verbose = TRUE,
+  measures = c("raw", "valid", "cumulative"),
   ...
 )
 
@@ -73,6 +74,11 @@ or \code{"full"} (to calculate relative frequencies for the full table).}
 for printing.}
 
 \item{verbose}{Toggle warnings and messages.}
+
+\item{measures}{Optional character vector, indicating the types of
+percents to be included. Only applies to frequencies, i.e. when \code{by} is
+\code{NULL}. Can be \code{"raw"} (includes \code{NA} values), \code{"valid"} (excludes \code{NA} values)
+or \code{"cumulative"} (excludes \code{NA} vlues).}
 
 \item{select}{Variables that will be included when performing the required
 tasks. Can be either


### PR DESCRIPTION
Currently contr.deviation()  is using @inheritParams from stats::contr.sum(), but because of how those parameters are written using the new style for linking S4 classes this is raising errors. I raised this as an issue in stats, but they said that this should be addressed in the package.